### PR TITLE
Refactoriza y mejora el conector de Koha

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Este conector utiliza la API REST de Koha y ha sido desarrollado siguiendo las m
 
 -   **Gestión Completa de Patrones:** Soporte para operaciones de Creación (`Create`), Lectura/Búsqueda (`Search`), Actualización (`Update`) y Eliminación (`Delete`).
 -   **Autenticación Flexible:** Compatibilidad con autenticación **Básica** (usuario/contraseña) y **OAuth2** (Client Credentials) para una integración segura.
--   **Arquitectura Robusta:** El código está refactorizado con un diseño modular que separa responsabilidades (autenticación, servicios, mapeo de datos), garantizando la estabilidad y facilitando el mantenimiento futuro.
+-   **Arquitectura Robusta y Mejorada:** El código sigue un diseño modular que separa responsabilidades (autenticación, servicios, mapeo de datos) y ha sido refactorizado para mejorar la robustez, el manejo de errores y la mantenibilidad.
 -   **Búsqueda por Atributos:** Permite buscar usuarios en Koha por UID, `userid`, `email` y `cardnumber` directamente desde Midpoint.
 
 ## 🚀 Instalación
@@ -55,8 +55,27 @@ Para una guía completa sobre cómo mapear los atributos del **Esquema de Extens
 El código fuente del conector sigue una arquitectura modular para separar responsabilidades:
 -   **`KohaConnector.java`**: Actúa como el orquestador principal que implementa las interfaces de ConnId.
 -   **`KohaAuthenticator.java`**: Centraliza la lógica de autenticación.
--   **Paquete `services`**: Gestiona la comunicación con los endpoints específicos de la API de Koha.
+-   **Paquete `services`**: Gestiona la comunicación con los endpoints específicos de la API de Koha, extendiendo funcionalidades de una clase base abstracta (`AbstractKohaService.java`) que maneja la lógica HTTP común y el manejo de errores mejorado.
 -   **Paquete `mappers`**: Se encarga de la transformación de datos entre Midpoint y el formato JSON de Koha.
+
+## 🐛 Troubleshooting
+
+Para obtener información de diagnóstico detallada, puedes habilitar el logging `TRACE` o `DEBUG` para este conector en Midpoint. Esto es especialmente útil si encuentras problemas durante la configuración o la ejecución de operaciones.
+
+Añade la siguiente configuración a tu archivo de logging de Midpoint (generalmente `logback.xml` o un archivo similar referenciado en la configuración de logging de Midpoint):
+
+```xml
+<logger name="com.identicum.connectors" level="TRACE"/>
+```
+
+Opciones de nivel de log:
+-   `ERROR`: Solo errores críticos que impiden el funcionamiento.
+-   `WARN`: Advertencias sobre situaciones potencialmente problemáticas.
+-   `INFO`: Mensajes informativos generales sobre el flujo de operaciones (por defecto para muchas operaciones del conector).
+-   `DEBUG`: Información detallada útil para depurar el flujo de control y las solicitudes/respuestas básicas.
+-   `TRACE`: El nivel más detallado, incluye payloads de solicitud/respuesta, transformaciones de atributos, etc. Puede generar mucho output.
+
+Revisa los logs de Midpoint para ver los mensajes detallados del conector. Esto te ayudará a ti o a los desarrolladores a entender qué está sucediendo.
 
 ## 📜 Licencia
 

--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
 	<parent>
 		<groupId>com.evolveum.polygon</groupId>
 		<artifactId>connector-parent</artifactId>
-		<version>1.4.2.14</version>
+		<version>1.5.2.0</version>
 	</parent>
 
 	<properties>
@@ -29,12 +29,31 @@
 		<dependency>
 			<groupId>com.evolveum.polygon</groupId>
 			<artifactId>connector-rest</artifactId>
-			<version>1.4.2.35</version>
+			<version>1.5.2.0</version>
+		</dependency>
+		<!-- Apache HttpClient 4.x -->
+		<dependency>
+			<groupId>org.apache.httpcomponents</groupId>
+			<artifactId>httpclient</artifactId>
+			<version>4.5.14</version>
 		</dependency>
 		<dependency>
 			<groupId>org.json</groupId>
 			<artifactId>json</artifactId>
-			<version>20231013</version>
+			<version>20250517</version>
+		</dependency>
+		<!-- JUnit 5 for testing -->
+		<dependency>
+			<groupId>org.junit.jupiter</groupId>
+			<artifactId>junit-jupiter-api</artifactId>
+			<version>5.9.3</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.junit.jupiter</groupId>
+			<artifactId>junit-jupiter-engine</artifactId>
+			<version>5.9.3</version>
+			<scope>test</scope>
 		</dependency>
 	</dependencies>
 

--- a/src/main/java/com/identicum/connectors/KohaConnector.java
+++ b/src/main/java/com/identicum/connectors/KohaConnector.java
@@ -8,6 +8,9 @@ import com.identicum.connectors.services.PatronService;
 import com.evolveum.polygon.rest.AbstractRestConnector;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.identityconnectors.common.logging.Log;
+import org.identityconnectors.common.StringUtil;
+import org.identityconnectors.framework.common.exceptions.ConfigurationException;
+import org.identityconnectors.framework.common.exceptions.ConnectorException;
 import org.identityconnectors.framework.common.exceptions.ConnectorIOException;
 import org.identityconnectors.framework.common.objects.*;
 import org.identityconnectors.framework.common.objects.filter.FilterTranslator;
@@ -17,7 +20,9 @@ import org.json.JSONArray;
 import org.json.JSONObject;
 
 import java.io.IOException;
+import java.util.Map;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 @ConnectorClass(displayNameKey = "connector.identicum.rest.display", configurationClass = KohaConfiguration.class)
 public class KohaConnector
@@ -37,13 +42,61 @@ public class KohaConnector
 	@Override
 	public void init(org.identityconnectors.framework.spi.Configuration configuration) {
 		super.init(configuration);
+
+		if (StringUtil.isBlank(getConfiguration().getServiceAddress())) {
+			throw new ConfigurationException("Service address (serviceAddress) must be provided.");
+		}
+
+		String authMethod = getConfiguration().getAuthMethod();
+
+		if (StringUtil.isBlank(authMethod)) {
+			throw new ConfigurationException("Authentication method (authMethod) must be provided.");
+		}
+
+		if ("BASIC".equalsIgnoreCase(authMethod)) {
+			if (StringUtil.isBlank(getConfiguration().getUsername())) {
+				throw new ConfigurationException("Username must be provided for BASIC authentication.");
+			}
+			// Optional: Check password, GuardedString needs specific handling for emptiness if desired.
+			// if (getConfiguration().getPassword() == null) { // Or a more specific check
+			//    throw new ConfigurationException("Password must be provided for BASIC authentication.");
+			// }
+		} else if ("OAUTH2".equalsIgnoreCase(authMethod)) {
+			if (StringUtil.isBlank(getConfiguration().getClientId())) {
+				throw new ConfigurationException("Client ID must be provided for OAUTH2 authentication.");
+			}
+			if (getConfiguration().getClientSecret() == null) { // GuardedString is null if not provided
+				throw new ConfigurationException("Client Secret must be provided for OAUTH2 authentication.");
+			}
+		} else {
+			throw new ConfigurationException("Invalid authentication method (authMethod) specified. Must be 'BASIC' or 'OAUTH2'.");
+		}
+
 		LOG.ok("Inicializando componentes del conector...");
 		KohaAuthenticator authenticator = new KohaAuthenticator(getConfiguration());
-		this.httpClient = authenticator.createAuthenticatedClient();
-		String serviceAddress = getConfiguration().getServiceAddress();
-		this.patronService = new PatronService(this.httpClient, serviceAddress);
-		this.categoryService = new CategoryService(this.httpClient, serviceAddress); // Re-introducido
-		LOG.ok("Conector Koha inicializado con éxito.");
+		this.httpClient = authenticator.createAuthenticatedClient(); // httpClient is created here
+
+		try {
+			String serviceAddress = getConfiguration().getServiceAddress();
+			this.patronService = new PatronService(this.httpClient, serviceAddress);
+			this.categoryService = new CategoryService(this.httpClient, serviceAddress); // Re-introducido
+			LOG.ok("Conector Koha inicializado con éxito.");
+		} catch (Exception e) { // Catch any exception during service initialization
+			LOG.error(e, "Error durante la inicialización de los servicios del conector después de crear httpClient.");
+			if (this.httpClient != null) {
+				try {
+					this.httpClient.close();
+					LOG.info("Cliente HTTP cerrado debido a un error durante la inicialización tardía del conector.");
+				} catch (IOException ioe) {
+					LOG.error(ioe, "Error al intentar cerrar el cliente HTTP durante el manejo de errores de init.");
+					// Do not re-throw ioe here to avoid masking the original exception 'e'.
+					// Add 'e' as a suppressed exception to 'ioe' if desired, or log 'e' separately.
+					// For now, just logging, original 'e' will be wrapped and thrown.
+				}
+			}
+			// Wrap and rethrow the original exception 'e'
+			throw new ConfigurationException("Fallo durante la inicialización de los servicios del conector: " + e.getMessage(), e);
+		}
 	}
 
 	@Override
@@ -53,38 +106,18 @@ public class KohaConnector
 		SchemaBuilder schemaBuilder = new SchemaBuilder(KohaConnector.class);
 
 		// --- Esquema para Cuentas (Patrones) ---
-		ObjectClassInfoBuilder accountBuilder = new ObjectClassInfoBuilder();
-		accountBuilder.setType(ObjectClass.ACCOUNT_NAME);
-		accountBuilder.addAttributeInfo(AttributeInfoBuilder.define(Uid.NAME)
-				.setNativeName(PatronMapper.KOHA_PATRON_ID_NATIVE_NAME).setType(String.class)
-				.setRequired(true).setCreateable(false).setUpdateable(false).setReadable(true).build());
-		AttributeMetadata nameMeta = PatronMapper.ATTRIBUTE_METADATA_MAP.get("userid");
-		accountBuilder.addAttributeInfo(AttributeInfoBuilder.define(Name.NAME)
-				.setNativeName(nameMeta.getKohaNativeName()).setType(String.class)
-				.setRequired(nameMeta.isRequired()).build());
-		for (AttributeMetadata meta : PatronMapper.ATTRIBUTE_METADATA_MAP.values()) {
-			if (!"userid".equals(meta.getConnIdName())) {
-				accountBuilder.addAttributeInfo(createAttributeInfo(meta));
-			}
-		}
-		schemaBuilder.defineObjectClass(accountBuilder.build());
+		ObjectClassInfo accountInfo = buildObjectClassInfo(ObjectClass.ACCOUNT_NAME,
+		                                                   PatronMapper.KOHA_PATRON_ID_NATIVE_NAME,
+		                                                   PatronMapper.ATTRIBUTE_METADATA_MAP,
+		                                                   "userid"); // "userid" is the ConnId Name for Patrons
+		schemaBuilder.defineObjectClass(accountInfo);
 
 		// --- Esquema para Grupos (Categorías) ---
-		ObjectClassInfoBuilder groupBuilder = new ObjectClassInfoBuilder();
-		groupBuilder.setType(ObjectClass.GROUP_NAME);
-		groupBuilder.addAttributeInfo(AttributeInfoBuilder.define(Uid.NAME)
-				.setNativeName(CategoryMapper.KOHA_CATEGORY_ID_NATIVE_NAME).setType(String.class)
-				.setRequired(true).setCreateable(false).setUpdateable(false).setReadable(true).build());
-		AttributeMetadata catNameMeta = CategoryMapper.ATTRIBUTE_METADATA_MAP.get("name");
-		groupBuilder.addAttributeInfo(AttributeInfoBuilder.define(Name.NAME)
-				.setNativeName(catNameMeta.getKohaNativeName()).setType(String.class)
-				.setRequired(catNameMeta.isRequired()).build());
-		for (AttributeMetadata meta : CategoryMapper.ATTRIBUTE_METADATA_MAP.values()) {
-			if (!"name".equals(meta.getConnIdName())) {
-				groupBuilder.addAttributeInfo(createAttributeInfo(meta));
-			}
-		}
-		schemaBuilder.defineObjectClass(groupBuilder.build());
+		ObjectClassInfo groupInfo = buildObjectClassInfo(ObjectClass.GROUP_NAME,
+		                                                 CategoryMapper.KOHA_CATEGORY_ID_NATIVE_NAME,
+		                                                 CategoryMapper.ATTRIBUTE_METADATA_MAP,
+		                                                 "name"); // "name" is the ConnId Name for Categories
+		schemaBuilder.defineObjectClass(groupInfo);
 
 		this.connectorSchema = schemaBuilder.build();
 		LOG.ok("Esquema construido con éxito.");
@@ -93,62 +126,82 @@ public class KohaConnector
 
 	@Override
 	public Uid create(ObjectClass oClass, Set<Attribute> attrs, OperationOptions options) {
+		LOG.ok("Iniciando Create para ObjectClass {0}, Atributos: {1}", oClass, attrs != null ? attrs.stream().map(Attribute::getName).collect(Collectors.toSet()) : "null");
+		String newUidValue = null;
 		try {
 			if (ObjectClass.ACCOUNT.is(oClass.getObjectClassValue())) {
 				JSONObject payload = patronMapper.buildPatronJson(attrs, true);
 				JSONObject response = patronService.createPatron(payload);
-
-				// Leemos el 'patron_id' de forma segura, sin asumir su tipo, y lo convertimos a String.
-				String newUid = String.valueOf(response.get(PatronMapper.KOHA_PATRON_ID_NATIVE_NAME));
-				return new Uid(newUid);
-
+				newUidValue = String.valueOf(response.get(PatronMapper.KOHA_PATRON_ID_NATIVE_NAME));
 			} else if (ObjectClass.GROUP.is(oClass.getObjectClassValue())) {
 				JSONObject payload = categoryMapper.buildCategoryJson(attrs, true);
 				JSONObject response = categoryService.createCategory(payload);
-
-				// Hacemos lo mismo para las categorías por consistencia.
-				String newUid = String.valueOf(response.get(CategoryMapper.KOHA_CATEGORY_ID_NATIVE_NAME));
-				return new Uid(newUid);
-
+				newUidValue = String.valueOf(response.get(CategoryMapper.KOHA_CATEGORY_ID_NATIVE_NAME));
 			} else {
 				throw new UnsupportedOperationException("Operación Create no soportada para: " + oClass.getObjectClassValue());
 			}
+			LOG.ok("Create para ObjectClass {0} completado. Uid: {1}", oClass, newUidValue);
+			return new Uid(newUidValue);
+		} catch (ConnectorException e) { // Catch specific ConnectorExceptions first
+			LOG.error(e, "Error de ConnectorException en Create para ObjectClass {0}", oClass.getObjectClassValue());
+			throw e; // Re-throw original ConnectorException
 		} catch (IOException e) {
-			throw new ConnectorIOException("Error en la operación CREATE: " + e.getMessage(), e);
+			LOG.error(e, "Error de IOException en Create para ObjectClass {0}", oClass.getObjectClassValue());
+			throw new ConnectorIOException("Error de IO en Create para " + oClass.getObjectClassValue() + ": " + e.getMessage(), e);
+		} catch (Exception e) {
+			LOG.error(e, "Error inesperado en Create para ObjectClass {0}", oClass.getObjectClassValue());
+			throw ConnectorException.wrap(e);
 		}
 	}
 
 	@Override
 	public Uid update(ObjectClass oClass, Uid uid, Set<Attribute> attrs, OperationOptions options) {
-		if (attrs == null || attrs.isEmpty()) return uid;
+		LOG.ok("Iniciando Update para ObjectClass {0}, Uid: {1}, Atributos: {2}", oClass, uid.getUidValue(), attrs != null ? attrs.stream().map(Attribute::getName).collect(Collectors.toSet()) : "null");
+		if (attrs == null || attrs.isEmpty()) {
+			LOG.ok("Update para ObjectClass {0}, Uid: {1} no requiere cambios (atributos vacíos).", oClass, uid.getUidValue());
+			return uid;
+		}
 		try {
 			if (ObjectClass.ACCOUNT.is(oClass.getObjectClassValue())) {
-				JSONObject existingPatron = patronService.getPatron(uid.getUidValue());
+				// Consider fetching only if necessary or let service handle optimistic locking if supported
+				// For now, matching existing logic structure:
+				JSONObject existingPatron = patronService.getPatron(uid.getUidValue()); // This could throw if not found
 				JSONObject changes = patronMapper.buildPatronJson(attrs, false);
 				for (String key : changes.keySet()) {
 					existingPatron.put(key, changes.get(key));
 				}
+				// Prune attributes that are not updateable according to metadata
+				// This logic might be better suited within the mapper or service
 				for (AttributeMetadata meta : PatronMapper.ATTRIBUTE_METADATA_MAP.values()) {
-					if (meta.isNotUpdateable() || meta.isNotCreatable()) {
+					if (meta.isNotUpdateable()) { // Only check NotUpdateable for update
 						existingPatron.remove(meta.getKohaNativeName());
 					}
 				}
 				patronService.updatePatron(uid.getUidValue(), existingPatron);
-				return uid;
 			} else if (ObjectClass.GROUP.is(oClass.getObjectClassValue())) {
 				JSONObject payload = categoryMapper.buildCategoryJson(attrs, false);
+				// Similar pruning could be applied for groups if necessary
 				categoryService.updateCategory(uid.getUidValue(), payload);
-				return uid;
 			} else {
 				throw new UnsupportedOperationException("Operación Update no soportada para: " + oClass.getObjectClassValue());
 			}
+			LOG.ok("Update para ObjectClass {0}, Uid: {1} completado.", oClass, uid.getUidValue());
+			return uid;
+		} catch (ConnectorException e) { // Catch specific ConnectorExceptions first
+			LOG.error(e, "Error de ConnectorException en Update para ObjectClass {0}, Uid {1}", oClass.getObjectClassValue(), uid.getUidValue());
+			throw e; // Re-throw original ConnectorException
 		} catch (IOException e) {
-			throw new ConnectorIOException("Error en UPDATE: " + e.getMessage(), e);
+			LOG.error(e, "Error de IOException en Update para ObjectClass {0}, Uid {1}", oClass.getObjectClassValue(), uid.getUidValue());
+			throw new ConnectorIOException("Error de IO en Update para " + oClass.getObjectClassValue() + ", Uid: " + uid.getUidValue() + ": " + e.getMessage(), e);
+		} catch (Exception e) {
+			LOG.error(e, "Error inesperado en Update para ObjectClass {0}, Uid {1}", oClass.getObjectClassValue(), uid.getUidValue());
+			throw ConnectorException.wrap(e);
 		}
 	}
 
 	@Override
 	public void delete(ObjectClass oClass, Uid uid, OperationOptions options) {
+		LOG.ok("Iniciando Delete para ObjectClass {0}, Uid: {1}", oClass, uid.getUidValue());
 		try {
 			if (ObjectClass.ACCOUNT.is(oClass.getObjectClassValue())) {
 				patronService.deletePatron(uid.getUidValue());
@@ -157,39 +210,78 @@ public class KohaConnector
 			} else {
 				throw new UnsupportedOperationException("Operación Delete no soportada para: " + oClass.getObjectClassValue());
 			}
+			LOG.ok("Delete para ObjectClass {0}, Uid: {1} completado.", oClass, uid.getUidValue());
+		} catch (ConnectorException e) { // Catch specific ConnectorExceptions first
+			LOG.error(e, "Error de ConnectorException en Delete para ObjectClass {0}, Uid {1}", oClass.getObjectClassValue(), uid.getUidValue());
+			throw e; // Re-throw original ConnectorException
 		} catch (IOException e) {
-			throw new ConnectorIOException("Error en DELETE: " + e.getMessage(), e);
+			LOG.error(e, "Error de IOException en Delete para ObjectClass {0}, Uid {1}", oClass.getObjectClassValue(), uid.getUidValue());
+			throw new ConnectorIOException("Error de IO en Delete para " + oClass.getObjectClassValue() + ", Uid: " + uid.getUidValue() + ": " + e.getMessage(), e);
+		} catch (Exception e) {
+			LOG.error(e, "Error inesperado en Delete para ObjectClass {0}, Uid {1}", oClass.getObjectClassValue(), uid.getUidValue());
+			throw ConnectorException.wrap(e);
 		}
 	}
 
 	@Override
 	public void executeQuery(ObjectClass oClass, KohaFilter filter, ResultsHandler handler, OperationOptions options) {
+		LOG.ok("Iniciando executeQuery para ObjectClass {0}. Filtro Uid: {1}, Filtro Name: {2}, Filtro Email: {3}, Filtro Cardnumber: {4}, Options: {5}",
+				oClass,
+				(filter != null ? filter.getByUid() : "N/A"),
+				(filter != null ? filter.getByName() : "N/A"),
+				(filter != null && filter instanceof KohaFilter ? ((KohaFilter)filter).getByEmail() : "N/A"), // Assuming KohaFilter has getByEmail
+				(filter != null && filter instanceof KohaFilter ? ((KohaFilter)filter).getByCardNumber() : "N/A"), // Assuming KohaFilter has getByCardNumber
+				options);
 		try {
 			if (ObjectClass.ACCOUNT.is(oClass.getObjectClassValue())) {
 				if (filter != null && filter.getByUid() != null) {
 					JSONObject patronJson = patronService.getPatron(filter.getByUid());
-					handler.handle(patronMapper.convertJsonToPatronObject(patronJson));
+					if (patronJson != null && patronJson.length() > 0) { // Check if patronJson is not null or empty
+						handler.handle(patronMapper.convertJsonToPatronObject(patronJson));
+						LOG.info("Resultados de búsqueda por UID para {0}: 1", oClass);
+					} else {
+						LOG.info("Resultados de búsqueda por UID para {0}: 0 (Patrón no encontrado o vacío)", oClass);
+					}
 				} else {
 					JSONArray results = patronService.searchPatrons(filter, options);
-					for (int i = 0; i < results.length(); i++) {
-						ConnectorObject co = patronMapper.convertJsonToPatronObject(results.getJSONObject(i));
-						if (co != null && !handler.handle(co)) break;
+					LOG.info("Resultados de búsqueda para {0}: {1}", oClass, results != null ? results.length() : 0);
+					if (results != null) {
+						for (int i = 0; i < results.length(); i++) {
+							ConnectorObject co = patronMapper.convertJsonToPatronObject(results.getJSONObject(i));
+							if (co != null && !handler.handle(co)) break;
+						}
 					}
 				}
 			} else if (ObjectClass.GROUP.is(oClass.getObjectClassValue())) {
 				if (filter != null && filter.getByUid() != null) {
 					JSONObject categoryJson = categoryService.getCategory(filter.getByUid());
-					handler.handle(categoryMapper.convertJsonToCategoryObject(categoryJson));
+					if (categoryJson != null && categoryJson.length() > 0) { // Check if categoryJson is not null or empty
+						handler.handle(categoryMapper.convertJsonToCategoryObject(categoryJson));
+						LOG.info("Resultados de búsqueda por UID para {0}: 1", oClass);
+					} else {
+						LOG.info("Resultados de búsqueda por UID para {0}: 0 (Categoría no encontrada o vacía)", oClass);
+					}
 				} else {
 					JSONArray results = categoryService.searchCategories(filter, options);
-					for (int i = 0; i < results.length(); i++) {
-						ConnectorObject co = categoryMapper.convertJsonToCategoryObject(results.getJSONObject(i));
-						if (co != null && !handler.handle(co)) break;
+					LOG.info("Resultados de búsqueda para {0}: {1}", oClass, results != null ? results.length() : 0);
+					if (results != null) {
+						for (int i = 0; i < results.length(); i++) {
+							ConnectorObject co = categoryMapper.convertJsonToCategoryObject(results.getJSONObject(i));
+							if (co != null && !handler.handle(co)) break;
+						}
 					}
 				}
 			}
+			LOG.ok("executeQuery para ObjectClass {0} completado.", oClass);
+		} catch (ConnectorException e) { // Catch specific ConnectorExceptions first
+			LOG.error(e, "Error de ConnectorException en executeQuery para ObjectClass {0}", oClass.getObjectClassValue());
+			throw e; // Re-throw original ConnectorException
 		} catch (IOException e) {
-			throw new ConnectorIOException("Error en EXECUTE_QUERY: " + e.getMessage(), e);
+			LOG.error(e, "Error de IOException en executeQuery para ObjectClass {0}", oClass.getObjectClassValue());
+			throw new ConnectorIOException("Error de IO en executeQuery para " + oClass.getObjectClassValue() + ": " + e.getMessage(), e);
+		} catch (Exception e) {
+			LOG.error(e, "Error inesperado en executeQuery para ObjectClass {0}", oClass.getObjectClassValue());
+			throw ConnectorException.wrap(e);
 		}
 	}
 
@@ -197,10 +289,37 @@ public class KohaConnector
 	public void test() {
 		LOG.ok("Iniciando prueba de conexión...");
 		try {
+			// Paso 1: Probar la obtención y validación del esquema
+			LOG.ok("Paso 1/2: Probando la obtención del esquema...");
+			Schema schema = schema(); // Llama al método schema() de esta clase
+			if (schema == null) {
+				throw new ConnectorIOException("La obtención del esquema retornó null.");
+			}
+			// Validar que el esquema contiene las ObjectClass esperadas
+			if (schema.findObjectClassInfo(ObjectClass.ACCOUNT_NAME) == null) {
+				throw new ConnectorIOException("El esquema no contiene la ObjectClass ACCOUNT.");
+			}
+			if (schema.findObjectClassInfo(ObjectClass.GROUP_NAME) == null) {
+				throw new ConnectorIOException("El esquema no contiene la ObjectClass GROUP.");
+			}
+			LOG.ok("Paso 1/2: Obtención y validación básica del esquema exitosa.");
+
+			// Paso 2: Probar búsqueda básica de patrones (conectividad y autenticación)
+			LOG.ok("Paso 2/2: Probando búsqueda básica de patrones (conectividad y autenticación)...");
 			patronService.searchPatrons(null, new OperationOptionsBuilder().setPageSize(1).build());
-			LOG.ok("Prueba de conexión exitosa.");
-		} catch (Exception e) {
-			throw new ConnectorIOException("La prueba de conexión falló: " + e.getMessage(), e);
+
+			LOG.ok("Prueba de conexión y configuración básica completada con éxito.");
+
+		} catch (ConnectorException e) { // Catch ConnectorException specifically (includes ConnectorIOException)
+			LOG.error(e, "La prueba del conector falló con ConnectorException: {0}", e.getMessage());
+			throw e; // Re-throw as is
+		} catch (IOException e) { // Catch IOException if not wrapped by services or schema()
+			LOG.error(e, "La prueba del conector falló con IOException: {0}", e.getMessage());
+			throw new ConnectorIOException("La prueba de conexión falló por IO: " + e.getMessage(), e);
+		} catch (Exception e) { // Catch any other unexpected exception
+			LOG.error(e, "La prueba del conector falló con una excepción inesperada: {0}", e.getMessage());
+			// Wrap in ConnectorIOException as it's the most common type for test() failures.
+			throw new ConnectorIOException("La prueba de conexión falló inesperadamente: " + e.getMessage(), e);
 		}
 	}
 
@@ -219,6 +338,39 @@ public class KohaConnector
 		} catch (IOException e) {
 			LOG.error("Error al cerrar el cliente HTTP: {0}", e.getMessage(), e);
 		}
+	}
+
+	private ObjectClassInfo buildObjectClassInfo(String objectClassType,
+	                                             String nativeIdAttributeName,
+	                                             java.util.Map<String, AttributeMetadata> attributeMetadataMap,
+	                                             String connIdNameAttribute) {
+	    ObjectClassInfoBuilder ociBuilder = new ObjectClassInfoBuilder();
+	    ociBuilder.setType(objectClassType);
+
+	    // UID attribute
+	    ociBuilder.addAttributeInfo(AttributeInfoBuilder.define(Uid.NAME)
+	            .setNativeName(nativeIdAttributeName).setType(String.class)
+	            .setRequired(true).setCreateable(false).setUpdateable(false).setReadable(true).build());
+
+	    // Name attribute
+	    AttributeMetadata nameMeta = attributeMetadataMap.get(connIdNameAttribute);
+	    if (nameMeta == null) {
+	        // Fallback or error if the primary name attribute is not in the map
+	        // For now, let's assume it's always present as per current logic
+	        LOG.warn("Primary name attribute '{0}' not found in metadata map for ObjectClass '{1}'. Schema might be incomplete.", connIdNameAttribute, objectClassType);
+	    } else {
+	         ociBuilder.addAttributeInfo(AttributeInfoBuilder.define(Name.NAME)
+	            .setNativeName(nameMeta.getKohaNativeName()).setType(String.class)
+	            .setRequired(nameMeta.isRequired()).build());
+	    }
+
+	    // Other attributes
+	    for (AttributeMetadata meta : attributeMetadataMap.values()) {
+	        if (!connIdNameAttribute.equals(meta.getConnIdName())) { // Exclude the one already added as Name.NAME
+	            ociBuilder.addAttributeInfo(createAttributeInfo(meta)); // Uses existing helper
+	        }
+	    }
+	    return ociBuilder.build();
 	}
 
 	private AttributeInfo createAttributeInfo(AttributeMetadata meta) {

--- a/src/main/java/com/identicum/connectors/mappers/PatronMapper.java
+++ b/src/main/java/com/identicum/connectors/mappers/PatronMapper.java
@@ -8,11 +8,14 @@ import org.json.JSONObject;
 
 import java.util.*;
 
+import org.identityconnectors.common.logging.Log;
+
 /**
  * Mapper especializado para los objetos de tipo Patrón (Account).
  * Contiene las definiciones de atributos de patrones y la lógica para su transformación.
  */
 public class PatronMapper extends BaseMapper {
+    private static final Log LOG = Log.getLog(PatronMapper.class);
 
     // --- Definiciones de Atributos de PATRONES ---
     public static final String KOHA_PATRON_ID_NATIVE_NAME = "patron_id";
@@ -88,42 +91,63 @@ public class PatronMapper extends BaseMapper {
      * Construye un objeto JSON para un Patrón a partir de atributos de ConnId.
      */
     public JSONObject buildPatronJson(Set<Attribute> attributes, boolean isCreate) {
+        LOG.ok("Construyendo JSON de Patrón para {0}. Atributos ConnId: {1}", (isCreate ? "CREATE" : "UPDATE"), attributes);
         JSONObject jo = new JSONObject();
         Set<String> processedKohaAttrs = new HashSet<>();
-        final String nameAttribute = "userid";
+        final String nameAttribute = "userid"; // ConnId Name attribute for Patrons
 
         for (Attribute attr : attributes) {
             String connIdAttrName = attr.getName();
-            if (Uid.NAME.equals(connIdAttrName)) continue;
+            if (Uid.NAME.equals(connIdAttrName)) {
+                LOG.ok("Trace Mapper: Omitiendo atributo Uid.NAME ({0}) directamente, se maneja por separado.", connIdAttrName);
+                continue;
+            }
 
             AttributeMetadata meta = Name.NAME.equals(connIdAttrName) ?
                     ATTRIBUTE_METADATA_MAP.get(nameAttribute) : ATTRIBUTE_METADATA_MAP.get(connIdAttrName);
+            LOG.ok("Trace Mapper: Procesando atributo ConnId: {0}, Meta: {1}", connIdAttrName, meta);
 
             if (meta == null) {
-                LOG.warn("BUILD_JSON: No hay metadatos para el atributo de Patrón '{0}'. Omitiendo.", connIdAttrName);
+                LOG.warn("No hay metadatos para el atributo de Patrón '{0}'. Omitiendo.", connIdAttrName);
                 continue;
             }
 
-            // Esta lógica es la que permite la flexibilidad.
-            // Si el atributo está marcado como no actualizable, se omite.
-            if (!isCreate && meta.isNotUpdateable()) continue;
-            if (isCreate && meta.isNotCreatable()) continue;
+            if (!isCreate && meta.isNotUpdateable()) {
+                LOG.ok("Trace Mapper: Omitiendo atributo {0} debido a que es no actualizable", connIdAttrName);
+                continue;
+            }
+            if (isCreate && meta.isNotCreatable()) {
+                LOG.ok("Trace Mapper: Omitiendo atributo {0} debido a que es no creable", connIdAttrName);
+                continue;
+            }
 
             List<Object> values = attr.getValue();
-            // Esta lógica permite "borrar" un campo enviando un nulo.
             if (values == null || values.isEmpty() || values.get(0) == null) {
-                if (!isCreate) jo.put(meta.getKohaNativeName(), JSONObject.NULL);
+                if (!isCreate) { // Only set to NULL for updates
+                    LOG.ok("Trace Mapper: Estableciendo {0} a NULL en JSON para UPDATE", meta.getKohaNativeName());
+                    jo.put(meta.getKohaNativeName(), JSONObject.NULL);
+                } else {
+                    LOG.ok("Trace Mapper: Omitiendo atributo {0} con valor nulo/vacío para CREATE.", connIdAttrName);
+                }
                 continue;
             }
-            if (processedKohaAttrs.contains(meta.getKohaNativeName())) continue;
+
+            // Avoid processing the same Koha native attribute name multiple times if ConnId attributes map to it
+            // (e.g. Name and a specific username attribute mapping to the same Koha field)
+            if (processedKohaAttrs.contains(meta.getKohaNativeName())) {
+                LOG.ok("Trace Mapper: Atributo Koha nativo '{0}' ya procesado (posiblemente por Name y userid mapeando al mismo). Omitiendo para ConnId '{1}'.", meta.getKohaNativeName(), connIdAttrName);
+                continue;
+            }
 
             Object kohaValue = meta.isMultivalued() ?
                     new JSONArray(values.stream().map(v -> convertConnIdValueToKohaJsonValue(v, meta)).filter(Objects::nonNull).toArray())
                     : convertConnIdValueToKohaJsonValue(values.get(0), meta);
 
+            LOG.ok("Trace Mapper: Mapeando ConnId '{0}' a Koha '{1}' con valor: {2}", connIdAttrName, meta.getKohaNativeName(), kohaValue);
             jo.put(meta.getKohaNativeName(), kohaValue);
             processedKohaAttrs.add(meta.getKohaNativeName());
         }
+        LOG.ok("JSON de Patrón construido: {0}", jo.toString(2));
         return jo;
     }
 
@@ -132,34 +156,62 @@ public class PatronMapper extends BaseMapper {
      * Convierte un objeto JSON de un Patrón en un ConnectorObject.
      */
     public ConnectorObject convertJsonToPatronObject(JSONObject kohaJson) {
-        if (kohaJson == null) return null;
-
-        ConnectorObjectBuilder builder = new ConnectorObjectBuilder().setObjectClass(ObjectClass.ACCOUNT);
-
-        String uidVal = String.valueOf(kohaJson.get(KOHA_PATRON_ID_NATIVE_NAME)); // Lectura segura
-        String nameVal = kohaJson.optString(ATTRIBUTE_METADATA_MAP.get("userid").getKohaNativeName(), null);
-
-        if (StringUtil.isBlank(uidVal)) {
-            LOG.error("CONVERT_JSON: Se encontró un Patrón sin UID. Se omitirá. JSON: {0}", kohaJson.toString());
+        LOG.ok("Convirtiendo JSON de Koha a ConnectorObject (Patrón): {0}", kohaJson.toString(2));
+        if (kohaJson == null) {
+            LOG.warn("El JSON de Koha proporcionado es nulo. Retornando nulo.");
             return null;
         }
 
-        builder.setUid(new Uid(uidVal));
-        builder.setName(new Name(nameVal != null ? nameVal : uidVal));
+        ConnectorObjectBuilder builder = new ConnectorObjectBuilder().setObjectClass(ObjectClass.ACCOUNT);
 
+        // UID es mandatorio. Koha usa 'patron_id'.
+        Object rawUid = kohaJson.opt(KOHA_PATRON_ID_NATIVE_NAME);
+        String uidVal = (rawUid != null) ? String.valueOf(rawUid) : null;
+
+        if (StringUtil.isBlank(uidVal)) {
+            LOG.error("Patrón JSON no tiene UID ({0}). JSON: {1}", KOHA_PATRON_ID_NATIVE_NAME, kohaJson.toString(2));
+            return null; // No se puede construir un ConnectorObject sin UID
+        }
+        builder.setUid(new Uid(uidVal));
+
+        // Name attribute - ConnId 'Name' (que mapea a 'userid' de Koha)
+        AttributeMetadata nameAttributeMeta = ATTRIBUTE_METADATA_MAP.get("userid");
+        String nameVal = null;
+        if (nameAttributeMeta != null && kohaJson.has(nameAttributeMeta.getKohaNativeName())) {
+            nameVal = kohaJson.optString(nameAttributeMeta.getKohaNativeName(), null);
+            LOG.ok("Trace Mapper: Mapeando Koha '{0}' a ConnId Name con valor: {1}", nameAttributeMeta.getKohaNativeName(), nameVal);
+        } else {
+            LOG.ok("Trace Mapper: Atributo Koha para Name (mapeado de 'userid') no encontrado o nulo en JSON. Usando UID como Name fallback.");
+        }
+        builder.setName(new Name(nameVal != null ? nameVal : uidVal)); // Fallback a UID si 'userid' no está o es nulo.
+
+        // Resto de los atributos
         for (AttributeMetadata meta : ATTRIBUTE_METADATA_MAP.values()) {
+            LOG.ok("Trace Mapper: Considerando atributo Koha '{0}' (ConnId: '{1}')", meta.getKohaNativeName(), meta.getConnIdName());
+
+            // Omitir el que ya se usó para Name.NAME si su ConnIdName es "userid"
             if ("userid".equals(meta.getConnIdName())) {
+                LOG.ok("Trace Mapper: Omitiendo el procesamiento explícito de '{0}' como atributo regular, ya manejado como Name.NAME.", meta.getConnIdName());
                 continue;
             }
+
             if (meta.isNotReadable() || !kohaJson.has(meta.getKohaNativeName()) || kohaJson.isNull(meta.getKohaNativeName())) {
+                LOG.ok("Trace Mapper: Omitiendo atributo Koha '{0}' porque no es leíble o no está presente/nulo en el JSON.", meta.getKohaNativeName());
                 continue;
             }
+
             Object kohaNativeVal = kohaJson.get(meta.getKohaNativeName());
             Object connIdVal = convertKohaValueToConnIdValue(kohaNativeVal, meta);
+
             if (connIdVal != null) {
+                LOG.ok("Trace Mapper: Mapeando Koha '{0}' a ConnId '{1}' con valor: {2}", meta.getKohaNativeName(), meta.getConnIdName(), connIdVal);
                 builder.addAttribute(AttributeBuilder.build(meta.getConnIdName(), connIdVal));
+            } else {
+                LOG.ok("Trace Mapper: Valor convertido para ConnId '{0}' (desde Koha '{1}') es nulo. No se añadirá.", meta.getConnIdName(), meta.getKohaNativeName());
             }
         }
-        return builder.build();
+        ConnectorObject resultObject = builder.build();
+        LOG.ok("ConnectorObject (Patrón) construido: {0}", resultObject.toString()); // toString() de ConnectorObject es informativo.
+        return resultObject;
     }
 }

--- a/src/main/java/com/identicum/connectors/services/AbstractKohaService.java
+++ b/src/main/java/com/identicum/connectors/services/AbstractKohaService.java
@@ -1,0 +1,217 @@
+package com.identicum.connectors.services;
+
+import org.apache.http.Header;
+import org.apache.http.HttpEntity;
+import org.apache.http.client.ClientProtocolException;
+import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.client.methods.HttpEntityEnclosingRequestBase;
+import org.apache.http.client.methods.HttpRequestBase;
+import org.apache.http.conn.HttpHostConnectException;
+import org.apache.http.entity.ByteArrayEntity;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.util.EntityUtils;
+import org.identityconnectors.common.StringUtil;
+import org.identityconnectors.common.logging.Log;
+import org.identityconnectors.framework.common.exceptions.AlreadyExistsException;
+import org.identityconnectors.framework.common.exceptions.ConnectionFailedException;
+import org.identityconnectors.framework.common.exceptions.ConnectorException;
+import org.identityconnectors.framework.common.exceptions.ConnectorIOException;
+// import org.identityconnectors.framework.common.exceptions.ConnectorRuntimeException; // Eliminada para pruebas
+import org.identityconnectors.framework.common.exceptions.InvalidAttributeValueException;
+import org.identityconnectors.framework.common.exceptions.PermissionDeniedException;
+import org.identityconnectors.framework.common.exceptions.UnknownUidException;
+import org.json.JSONException;
+import org.json.JSONObject;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.UnsupportedEncodingException;
+import java.net.SocketTimeoutException;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import java.util.zip.GZIPInputStream;
+
+public abstract class AbstractKohaService {
+
+    private static final Log LOG = Log.getLog(AbstractKohaService.class);
+    protected final CloseableHttpClient httpClient;
+    protected final String serviceAddress;
+
+    public AbstractKohaService(CloseableHttpClient httpClient, String serviceAddress) {
+        this.httpClient = httpClient;
+        this.serviceAddress = serviceAddress;
+    }
+
+    protected abstract String getEndpoint();
+    protected abstract String getResourceName();
+
+    protected String getBaseUrl() {
+        return this.serviceAddress + "/api/v1" + getEndpoint();
+    }
+
+    protected JSONObject callRequestWithEntity(HttpEntityEnclosingRequestBase request, JSONObject payload) throws ConnectorException, IOException {
+        request.setHeader("Content-Type", "application/json");
+        request.setHeader("Accept", "application/json");
+        if (payload != null) {
+            request.setEntity(new ByteArrayEntity(payload.toString().getBytes(StandardCharsets.UTF_8)));
+        }
+
+        LOG.ok("Trace Mapper: Executing {0} request to {1}", request.getMethod(), request.getURI());
+        if (payload != null) {
+            LOG.ok("Trace Mapper: Request payload for {0} {1}: {2}", request.getMethod(), request.getURI(), payload.toString(2));
+        }
+
+        try (CloseableHttpResponse response = httpClient.execute(request)) {
+            processResponseErrors(response, request);
+            String result = EntityUtils.toString(response.getEntity(), StandardCharsets.UTF_8);
+            // If status code is 204 (No Content) or the result is blank, return an empty JSON object.
+            // This handles cases where the API successfully processes a request but doesn't return a body (e.g., PUT/DELETE),
+            // or when a POST might return 201 Created without a body (though often it returns the created resource).
+            if (response.getStatusLine().getStatusCode() == 204 || StringUtil.isBlank(result)) {
+                LOG.ok("Trace Mapper: Response for {0} {1}: Empty or No Content.", request.getMethod(), request.getURI());
+                return new JSONObject();
+            }
+            LOG.ok("Trace Mapper: Response body for {0} {1}: {2}", request.getMethod(), request.getURI(), result);
+            return new JSONObject(result);
+        } catch (HttpHostConnectException e) {
+            LOG.error(e, "Connection to Koha service at ''{0}'' failed for {1} {2}.", serviceAddress, request.getMethod(), request.getURI());
+            throw new ConnectionFailedException("Connection to Koha service at '" + serviceAddress + "' failed. Details: " + e.getMessage(), e);
+        } catch (SocketTimeoutException e) {
+            LOG.error(e, "Connection to Koha service timed out for {0} {1}.", request.getMethod(), request.getURI());
+            throw new ConnectionFailedException("Connection to Koha service timed out for request to '" + request.getURI() + "'. Details: " + e.getMessage(), e);
+        } catch (ClientProtocolException e) {
+            LOG.error(e, "HTTP protocol error during {0} {1}.", request.getMethod(), request.getURI());
+            throw new ConnectorIOException("HTTP protocol error during request to '" + request.getURI() + "'. Details: " + e.getMessage(), e);
+        } catch (IOException e) {
+            LOG.error(e, "IO error during {0} {1}.", request.getMethod(), request.getURI());
+            throw new ConnectorIOException("IO error during request to '" + request.getURI() + "'. Details: " + e.getMessage(), e);
+        } catch (JSONException e) {
+            LOG.error(e, "Failed to parse JSON response for {0} {1}.", request.getMethod(), request.getURI());
+            throw new ConnectorException("Failed to parse JSON response from " + request.getURI() + ". Details: " + e.getMessage(), e);
+        }
+    }
+
+    protected String callRequest(HttpRequestBase request) throws ConnectorException, IOException {
+        request.setHeader("Accept", "application/json");
+        request.setHeader("Accept-Encoding", "gzip");
+
+        LOG.ok("Trace Mapper: Executing {0} request to {1}", request.getMethod(), request.getURI());
+
+        try (CloseableHttpResponse response = httpClient.execute(request)) {
+            processResponseErrors(response, request);
+            HttpEntity entity = response.getEntity();
+            if (entity == null) {
+                // If there's no entity (e.g. 204 No Content), return empty string.
+                // This is consistent with how EntityUtils.toString(null) would behave if not for our check.
+                LOG.ok("Trace Mapper: Response for {0} {1}: No entity in response.", request.getMethod(), request.getURI());
+                return "";
+            }
+            InputStream inputStream = entity.getContent();
+            Header contentEncoding = entity.getContentEncoding();
+            if (contentEncoding != null && "gzip".equalsIgnoreCase(contentEncoding.getValue())) {
+                inputStream = new GZIPInputStream(inputStream);
+            }
+
+            // Read the input stream into a byte array before converting to string
+            // This avoids issues with character encoding if the stream is read incrementally as chars.
+            java.io.ByteArrayOutputStream buffer = new java.io.ByteArrayOutputStream();
+            int nRead;
+            byte[] data = new byte[4096]; // Buffer size
+            while ((nRead = inputStream.read(data, 0, data.length)) != -1) {
+                buffer.write(data, 0, nRead);
+            }
+            buffer.flush();
+            byte[] bytes = buffer.toByteArray();
+            String responseBodyString = new String(bytes, StandardCharsets.UTF_8);
+            LOG.ok("Trace Mapper: Response body for {0} {1}: {2}", request.getMethod(), request.getURI(), responseBodyString);
+            return responseBodyString;
+        } catch (HttpHostConnectException e) {
+            LOG.error(e, "Connection to Koha service at ''{0}'' failed for {1} {2}.", serviceAddress, request.getMethod(), request.getURI());
+            throw new ConnectionFailedException("Connection to Koha service at '" + serviceAddress + "' failed. Details: " + e.getMessage(), e);
+        } catch (SocketTimeoutException e) {
+            LOG.error(e, "Connection to Koha service timed out for {0} {1}.", request.getMethod(), request.getURI());
+            throw new ConnectionFailedException("Connection to Koha service timed out for request to '" + request.getURI() + "'. Details: " + e.getMessage(), e);
+        } catch (ClientProtocolException e) {
+            LOG.error(e, "HTTP protocol error during {0} {1}.", request.getMethod(), request.getURI());
+            throw new ConnectorIOException("HTTP protocol error during request to '" + request.getURI() + "'. Details: " + e.getMessage(), e);
+        } catch (IOException e) {
+            LOG.error(e, "IO error during {0} {1}.", request.getMethod(), request.getURI());
+            throw new ConnectorIOException("IO error during request to '" + request.getURI() + "'. Details: " + e.getMessage(), e);
+        }
+    }
+
+    protected void processResponseErrors(CloseableHttpResponse response, HttpRequestBase request) throws ConnectorException {
+        int statusCode = response.getStatusLine().getStatusCode();
+        if (statusCode >= 200 && statusCode < 300) {
+            return; // No error
+        }
+
+        String body = "";
+        try {
+            HttpEntity entity = response.getEntity();
+            if (entity != null) {
+                body = EntityUtils.toString(entity); // Read the body for error reporting
+            }
+        } catch (IOException e) {
+            LOG.warn(e, "Error reading error response body for {0} {1}.", request.getMethod(), request.getURI());
+        }
+
+        LOG.error("Error in HTTP response for {0} {1}. Status: {2}, Reason: {3}, Body: {4}",
+                request.getMethod(), request.getURI(), statusCode, response.getStatusLine().getReasonPhrase(), body);
+
+        String resourceContext = "Koha " + getResourceName() + " API";
+        String requestDesc = request.getMethod() + " " + request.getURI();
+
+        switch (statusCode) {
+            case 400:
+                String lowerBody = body.toLowerCase();
+                // More specific checks for "already exists" based on resource type
+                if (getResourceName().equalsIgnoreCase("patron") &&
+                    (lowerBody.contains("patron already exists") || lowerBody.contains("cardnumber already exists"))) {
+                    throw new AlreadyExistsException(resourceContext + " reported resource already exists. Request: " + requestDesc + ", Body: " + body);
+                } else if (getResourceName().equalsIgnoreCase("category") &&
+                           (lowerBody.contains("already exists") || lowerBody.contains("categorycode_exists") || lowerBody.contains("description_already_exists"))) {
+                    throw new AlreadyExistsException(resourceContext + " reported resource already exists. Request: " + requestDesc + ", Body: " + body);
+                }
+                throw new InvalidAttributeValueException(resourceContext + " Bad Request. Request: " + requestDesc + ", Status: " + statusCode + ", Body: " + body);
+            case 401:
+                throw new PermissionDeniedException("Authentication failed for " + resourceContext + ". Request: " + requestDesc + ", Status: " + statusCode + ", Body: " + body);
+            case 403:
+                throw new PermissionDeniedException("Permission denied for " + resourceContext + ". Request: " + requestDesc + ", Status: " + statusCode + ", Body: " + body);
+            case 404:
+                String uidPart = "";
+                // Attempt to extract last part of path as potential UID/ID
+                String[] pathSegments = request.getURI().getPath().split("/");
+                if (pathSegments.length > 0) {
+                    uidPart = pathSegments[pathSegments.length -1];
+                }
+                // Only throw UnknownUidException for operations that typically target a specific resource by ID
+                if (request.getMethod().equals("GET") || request.getMethod().equals("PUT") || request.getMethod().equals("DELETE")) {
+                    throw new UnknownUidException("Koha " + getResourceName() + " not found (ID/Code: " + uidPart + "). Request: " + requestDesc + ", Status: " + statusCode + ", Body: " + body);
+                }
+                // For other methods like POST to a non-existent base path, or other 404s.
+                throw new ConnectorIOException(resourceContext + " endpoint/resource not found. Request: " + requestDesc + ", Status: " + statusCode + ", Body: " + body);
+            case 409: // Conflict
+                throw new AlreadyExistsException(resourceContext + " Conflict (e.g. resource version mismatch, or state prevents operation). Request: " + requestDesc + ", Status: " + statusCode + ", Body: " + body);
+            case 500:
+            case 502:
+            case 503:
+            case 504:
+                throw new ConnectionFailedException(resourceContext + " server error or temporary unavailability. Request: " + requestDesc + ", Status: " + statusCode + ", Body: " + body);
+            default:
+                throw new ConnectorIOException("Unhandled " + resourceContext + " error. Request: " + requestDesc + ", Status: " + statusCode + ", Body: " + body);
+        }
+    }
+
+    protected String urlEncodeUTF8(String s) {
+        if (s == null) return ""; // Handle null input gracefully
+        try {
+            return URLEncoder.encode(s, StandardCharsets.UTF_8.name());
+        } catch (UnsupportedEncodingException e) {
+            // This should be virtually impossible on any modern Java platform
+            LOG.error(e, "UTF-8 encoding not supported, which is highly unusual.");
+            // Usar RuntimeException como fallback temporal si ConnectorRuntimeException no se encuentra.
+            throw new RuntimeException("UTF-8 encoding not supported. Original error: " + e.getMessage(), e);
+        }
+    }
+}

--- a/src/main/java/com/identicum/connectors/services/CategoryService.java
+++ b/src/main/java/com/identicum/connectors/services/CategoryService.java
@@ -1,78 +1,81 @@
 package com.identicum.connectors.services;
 
 import com.identicum.connectors.KohaFilter;
-import org.apache.http.Header;
-import org.apache.http.HttpEntity;
 import org.apache.http.client.methods.*;
-import org.apache.http.entity.ByteArrayEntity;
 import org.apache.http.impl.client.CloseableHttpClient;
-import org.apache.http.util.EntityUtils;
 import org.identityconnectors.common.StringUtil;
 import org.identityconnectors.common.logging.Log;
 import org.identityconnectors.framework.common.exceptions.ConnectorException;
-import org.identityconnectors.framework.common.exceptions.ConnectorIOException;
+// ConnectorRuntimeException is imported by AbstractKohaService's wildcard import if needed
 import org.identityconnectors.framework.common.objects.OperationOptions;
 import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
 
 import java.io.IOException;
-import java.io.InputStream;
-import java.io.UnsupportedEncodingException;
-import java.net.URLEncoder;
-import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
-import java.util.Arrays;
+import java.util.Arrays; // Keep this if it's used, though current refactoring might remove its direct use.
 import java.util.List;
-import java.util.zip.GZIPInputStream;
 
 /**
  * Servicio para gestionar las operaciones CRUD y de búsqueda para las Categorías de Patrones de Koha.
  */
-public class CategoryService {
+public class CategoryService extends AbstractKohaService {
 
     private static final Log LOG = Log.getLog(CategoryService.class);
-    private static final String API_BASE_PATH = "/api/v1";
-    private static final String ENDPOINT = "/patron_categories";
-
-    private final CloseableHttpClient httpClient;
-    private final String serviceAddress;
+    // API_BASE_PATH and ENDPOINT are handled by AbstractKohaService now
 
     public CategoryService(CloseableHttpClient httpClient, String serviceAddress) {
-        this.httpClient = httpClient;
-        this.serviceAddress = serviceAddress;
+        super(httpClient, serviceAddress);
     }
 
-    private String getBaseUrl() {
-        return this.serviceAddress + API_BASE_PATH + ENDPOINT;
+    @Override
+    protected String getEndpoint() {
+        return "/patron_categories";
     }
 
-    public JSONObject getCategory(String uid) throws IOException {
+    @Override
+    protected String getResourceName() {
+        return "category";
+    }
+
+    // getBaseUrl() is inherited
+
+    public JSONObject getCategory(String uid) throws ConnectorException, IOException {
         HttpGet request = new HttpGet(getBaseUrl() + "/" + uid);
-        String responseBody = callRequest(request);
-        return new JSONObject(responseBody);
+        String responseBody = callRequest(request); // Inherited
+        try {
+            if (StringUtil.isBlank(responseBody)) {
+                 // Consistent with getPatron, if callRequest returns empty for 200/204.
+                return new JSONObject();
+            }
+            return new JSONObject(responseBody);
+        } catch (JSONException e) {
+            throw new ConnectorException("Failed to parse JSON response for getCategory UID " + uid + ". Response: " + responseBody, e);
+        }
     }
 
-    public JSONObject createCategory(JSONObject payload) throws IOException {
+    public JSONObject createCategory(JSONObject payload) throws ConnectorException, IOException {
         HttpPost request = new HttpPost(getBaseUrl());
-        return callRequestWithEntity(request, payload);
+        return callRequestWithEntity(request, payload); // Inherited
     }
 
-    public void updateCategory(String uid, JSONObject payload) throws IOException {
+    public void updateCategory(String uid, JSONObject payload) throws ConnectorException, IOException {
         HttpPut request = new HttpPut(getBaseUrl() + "/" + uid);
-        callRequestWithEntity(request, payload);
+        callRequestWithEntity(request, payload); // Inherited, ignore return for void
     }
 
-    public void deleteCategory(String uid) throws IOException {
+    public void deleteCategory(String uid) throws ConnectorException, IOException {
         HttpDelete request = new HttpDelete(getBaseUrl() + "/" + uid);
-        callRequest(request);
+        callRequest(request); // Inherited
     }
 
-    public JSONArray searchCategories(KohaFilter filter, OperationOptions opts) throws IOException {
+    public JSONArray searchCategories(KohaFilter filter, OperationOptions opts) throws ConnectorException, IOException {
         JSONArray allResults = new JSONArray();
         int pageSize = (opts != null && opts.getPageSize() != null) ? opts.getPageSize() : 100;
         int currentPage = 1;
         boolean moreResults;
+        String fullUrl = ""; // For logging
 
         do {
             List<String> queryParams = new ArrayList<>();
@@ -80,37 +83,49 @@ public class CategoryService {
             queryParams.add("_page=" + currentPage);
 
             if (filter != null && StringUtil.isNotBlank(filter.getByName())) {
-                queryParams.add("description=" + urlEncodeUTF8(filter.getByName()));
+                // For categories, Koha typically filters by 'description' for the name/description field
+                queryParams.add("description=" + urlEncodeUTF8(filter.getByName())); // urlEncodeUTF8 inherited
             }
 
-            String fullUrl = getBaseUrl() + "?" + String.join("&", queryParams);
+            fullUrl = getBaseUrl() + "?" + String.join("&", queryParams);
             HttpGet request = new HttpGet(fullUrl);
-            LOG.ok("CATEGORY_SEARCH: URL: {0}", request.getURI());
+            LOG.info("CATEGORY_SEARCH: URL: {0}", request.getURI()); // Changed from LOG.ok
 
-            String response = callRequest(request);
+            String response = callRequest(request); // Inherited
             JSONArray pageResults;
 
             if (StringUtil.isBlank(response)) {
                 pageResults = new JSONArray();
             } else {
                 try {
-                    pageResults = new JSONArray(response);
-                } catch (JSONException e) {
-                    try {
-                        JSONObject responseObject = new JSONObject(response);
-                        pageResults = responseObject.optJSONArray("patron_categories");
-                        if (pageResults == null) {
-                            pageResults = new JSONArray(Arrays.asList(responseObject));
-                        }
-                    } catch (JSONException ex) {
-                        throw new ConnectorException("Respuesta JSON inválida de Koha al buscar categorías: " + response, ex);
+                    // Koha's category search usually returns a direct array.
+                    // However, to be safe and consistent with PatronService's potential single object response:
+                    if (response.trim().startsWith("{")) {
+                         JSONObject responseObject = new JSONObject(response);
+                         // Check if the response has a "patron_categories" array, common in some paginated Koha responses
+                         if (responseObject.has("patron_categories") && responseObject.get("patron_categories") instanceof JSONArray) {
+                            pageResults = responseObject.getJSONArray("patron_categories");
+                         } else {
+                            pageResults = new JSONArray();
+                            pageResults.put(responseObject);
+                         }
+                    } else if (response.trim().startsWith("[")) {
+                        pageResults = new JSONArray(response);
+                    } else {
+                        throw new JSONException("Response is neither a JSON object nor a JSON array.");
                     }
+                } catch (JSONException e) {
+                     throw new ConnectorException("Respuesta JSON inválida de Koha al buscar categorías. URL: " + fullUrl + ", Response: " + response, e);
                 }
             }
 
             if (pageResults.length() > 0) {
                 for (int i = 0; i < pageResults.length(); i++) {
-                    allResults.put(pageResults.getJSONObject(i));
+                     try {
+                        allResults.put(pageResults.getJSONObject(i));
+                    } catch (JSONException e) {
+                         throw new ConnectorException("Error processing individual category from search results. URL: " + fullUrl + ", Entry: " + pageResults.opt(i), e);
+                    }
                 }
             }
 
@@ -124,77 +139,6 @@ public class CategoryService {
         return allResults;
     }
 
-
-    // --- Métodos de ayuda para ejecutar peticiones HTTP (idénticos a PatronService) ---
-
-    private JSONObject callRequestWithEntity(HttpEntityEnclosingRequestBase request, JSONObject payload) throws IOException {
-        request.setHeader("Content-Type", "application/json");
-        request.setHeader("Accept", "application/json");
-        if (payload != null) {
-            request.setEntity(new ByteArrayEntity(payload.toString().getBytes(StandardCharsets.UTF_8)));
-        }
-
-        try (CloseableHttpResponse response = httpClient.execute(request)) {
-            processResponseErrors(response);
-            String result = EntityUtils.toString(response.getEntity(), StandardCharsets.UTF_8);
-            if (response.getStatusLine().getStatusCode() == 204 || StringUtil.isBlank(result)) {
-                return new JSONObject();
-            }
-            return new JSONObject(result);
-        } catch (JSONException e) {
-            throw new ConnectorException("Fallo al parsear respuesta JSON para " + request.getURI(), e);
-        }
-    }
-
-    private String callRequest(HttpRequestBase request) throws IOException {
-        request.setHeader("Accept", "application/json");
-        request.setHeader("Accept-Encoding", "gzip");
-
-        try (CloseableHttpResponse response = httpClient.execute(request)) {
-            processResponseErrors(response);
-            HttpEntity entity = response.getEntity();
-
-            // --- CORRECCIÓN APLICADA ---
-            if (entity == null) {
-                return ""; // Devolver un string vacío si no hay cuerpo de respuesta
-            }
-
-            InputStream inputStream = entity.getContent();
-            Header contentEncoding = entity.getContentEncoding();
-            if (contentEncoding != null && "gzip".equalsIgnoreCase(contentEncoding.getValue())) {
-                inputStream = new GZIPInputStream(inputStream);
-            }
-            return new String(inputStream.readAllBytes(), StandardCharsets.UTF_8);
-        }
-    }
-
-    private void processResponseErrors(CloseableHttpResponse response) throws ConnectorIOException {
-        int statusCode = response.getStatusLine().getStatusCode();
-        if (statusCode >= 200 && statusCode < 300) {
-            return; // Sin error
-        }
-
-        String body = "";
-        try {
-            HttpEntity entity = response.getEntity();
-            if (entity != null) {
-                body = EntityUtils.toString(entity);
-            }
-        } catch (IOException e) {
-            // No hacer nada
-        }
-
-        LOG.error("Error en la respuesta HTTP. Status: {0}, Razón: {1}, Cuerpo: {2}",
-                statusCode, response.getStatusLine().getReasonPhrase(), body);
-
-        throw new ConnectorIOException("Error en la API de Koha. Status: " + statusCode + " " + response.getStatusLine().getReasonPhrase());
-    }
-
-    private String urlEncodeUTF8(String s) {
-        try {
-            return URLEncoder.encode(s, StandardCharsets.UTF_8.name());
-        } catch (UnsupportedEncodingException e) {
-            throw new ConnectorException("La codificación UTF-8 no está soportada, esto no debería ocurrir.", e);
-        }
-    }
+    // Removed duplicated helper methods: callRequestWithEntity, callRequest, processResponseErrors, urlEncodeUTF8
+    // They are now inherited from AbstractKohaService.
 }

--- a/src/main/java/com/identicum/connectors/services/PatronService.java
+++ b/src/main/java/com/identicum/connectors/services/PatronService.java
@@ -1,78 +1,82 @@
 package com.identicum.connectors.services;
 
 import com.identicum.connectors.KohaFilter;
-import org.apache.http.Header;
-import org.apache.http.HttpEntity;
 import org.apache.http.client.methods.*;
-import org.apache.http.entity.ByteArrayEntity;
 import org.apache.http.impl.client.CloseableHttpClient;
-import org.apache.http.util.EntityUtils;
 import org.identityconnectors.common.StringUtil;
 import org.identityconnectors.common.logging.Log;
 import org.identityconnectors.framework.common.exceptions.ConnectorException;
-import org.identityconnectors.framework.common.exceptions.ConnectorIOException;
+// ConnectorRuntimeException is imported by AbstractKohaService's wildcard import if needed
 import org.identityconnectors.framework.common.objects.OperationOptions;
 import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
 
 import java.io.IOException;
-import java.io.InputStream;
-import java.io.UnsupportedEncodingException;
-import java.net.URLEncoder;
-import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
-import java.util.zip.GZIPInputStream;
 
 /**
  * Servicio para gestionar las operaciones CRUD y de búsqueda para los Patrones de Koha.
  */
-public class PatronService {
+public class PatronService extends AbstractKohaService {
 
     private static final Log LOG = Log.getLog(PatronService.class);
-    private static final String API_BASE_PATH = "/api/v1";
-    private static final String ENDPOINT = "/patrons";
-
-    private final CloseableHttpClient httpClient;
-    private final String serviceAddress;
+    // API_BASE_PATH and ENDPOINT are handled by AbstractKohaService now
 
     public PatronService(CloseableHttpClient httpClient, String serviceAddress) {
-        this.httpClient = httpClient;
-        this.serviceAddress = serviceAddress;
+        super(httpClient, serviceAddress);
     }
 
-    private String getBaseUrl() {
-        return this.serviceAddress + API_BASE_PATH + ENDPOINT;
+    @Override
+    protected String getEndpoint() {
+        return "/patrons";
     }
 
-    public JSONObject getPatron(String uid) throws IOException {
+    @Override
+    protected String getResourceName() {
+        return "patron";
+    }
+
+    // getBaseUrl() is inherited from AbstractKohaService
+
+    public JSONObject getPatron(String uid) throws ConnectorException, IOException {
         HttpGet request = new HttpGet(getBaseUrl() + "/" + uid);
-        String responseBody = callRequest(request);
-        return new JSONObject(responseBody);
+        String responseBody = callRequest(request); // Inherited method
+        try {
+            if (StringUtil.isBlank(responseBody)) {
+                // If callRequest returns an empty string (e.g., for a 204 or truly empty 200 response),
+                // return an empty JSON object. processResponseErrors would have handled 404.
+                return new JSONObject();
+            }
+            return new JSONObject(responseBody);
+        } catch (JSONException e) {
+            throw new ConnectorException("Failed to parse JSON response for getPatron UID " + uid + ". Response: " + responseBody, e);
+        }
     }
 
-    public JSONObject createPatron(JSONObject payload) throws IOException {
+    public JSONObject createPatron(JSONObject payload) throws ConnectorException, IOException {
         HttpPost request = new HttpPost(getBaseUrl());
-        return callRequestWithEntity(request, payload);
+        return callRequestWithEntity(request, payload); // Inherited method
     }
 
-    public void updatePatron(String uid, JSONObject payload) throws IOException {
+    public void updatePatron(String uid, JSONObject payload) throws ConnectorException, IOException {
         HttpPut request = new HttpPut(getBaseUrl() + "/" + uid);
-        callRequestWithEntity(request, payload);
+        callRequestWithEntity(request, payload); // Inherited method, returns JSONObject but we ignore it for void method
     }
 
-    public void deletePatron(String uid) throws IOException {
+    public void deletePatron(String uid) throws ConnectorException, IOException {
         HttpDelete request = new HttpDelete(getBaseUrl() + "/" + uid);
-        callRequest(request);
+        callRequest(request); // Inherited method
     }
 
-    public JSONArray searchPatrons(KohaFilter filter, OperationOptions opts) throws IOException {
+    public JSONArray searchPatrons(KohaFilter filter, OperationOptions opts) throws ConnectorException, IOException {
         JSONArray allResults = new JSONArray();
         int pageSize = (opts != null && opts.getPageSize() != null) ? opts.getPageSize() : 100;
         int currentPage = 1;
         boolean moreResults;
+        String fullUrl = ""; // For logging in case of error
 
         do {
             List<String> queryParams = new ArrayList<>();
@@ -80,40 +84,54 @@ public class PatronService {
             queryParams.add("_page=" + currentPage);
 
             if (filter != null) {
-                if (StringUtil.isNotBlank(filter.getByName())) queryParams.add("userid=" + urlEncodeUTF8(filter.getByName()));
+                if (StringUtil.isNotBlank(filter.getByName())) queryParams.add("userid=" + urlEncodeUTF8(filter.getByName())); // urlEncodeUTF8 is inherited
                 if (StringUtil.isNotBlank(filter.getByEmail())) queryParams.add("email=" + urlEncodeUTF8(filter.getByEmail()));
                 if (filter.getByCardNumber() != null) queryParams.add("cardnumber=" + urlEncodeUTF8(filter.getByCardNumber()));
             }
 
-            String fullUrl = getBaseUrl() + "?" + String.join("&", queryParams);
+            fullUrl = getBaseUrl() + "?" + String.join("&", queryParams);
             HttpGet request = new HttpGet(fullUrl);
-            LOG.ok("PATRON_SEARCH: URL: {0}", request.getURI());
+            LOG.info("PATRON_SEARCH: URL: {0}", request.getURI()); // Changed from LOG.ok
 
-            String response = callRequest(request);
+            String response = callRequest(request); // Inherited method
             JSONArray pageResults;
 
-            // Si la respuesta está vacía (posiblemente por paginación que ya no devuelve más), no hacer nada.
             if (StringUtil.isBlank(response)) {
                 pageResults = new JSONArray();
             } else {
                 try {
-                    pageResults = new JSONArray(response);
-                } catch (JSONException e) {
-                    try {
-                        JSONObject responseObject = new JSONObject(response);
-                        pageResults = responseObject.optJSONArray("patrons");
-                        if (pageResults == null) {
-                            pageResults = new JSONArray(Arrays.asList(responseObject));
-                        }
-                    } catch (JSONException ex) {
-                        throw new ConnectorException("Respuesta JSON inválida de Koha al buscar patrones: " + response, ex);
+                    // Koha's patron search can return a single object if only one result, or an array.
+                    // It can also sometimes wrap results in a "patrons: []" structure.
+                    if (response.trim().startsWith("{")) {
+                         JSONObject responseObject = new JSONObject(response);
+                         // Check if the response has a "patrons" array, common in some paginated Koha responses
+                         if (responseObject.has("patrons") && responseObject.get("patrons") instanceof JSONArray) {
+                            pageResults = responseObject.getJSONArray("patrons");
+                         } else {
+                            // Single result, or a structure we don't explicitly handle as multi-patron
+                            // Wrap it in an array for consistent processing
+                            pageResults = new JSONArray();
+                            pageResults.put(responseObject);
+                         }
+                    } else if (response.trim().startsWith("[")) {
+                        // Response is directly an array
+                        pageResults = new JSONArray(response);
+                    } else {
+                        // Unrecognized JSON structure
+                        throw new JSONException("Response is neither a JSON object nor a JSON array.");
                     }
+                } catch (JSONException e) {
+                    throw new ConnectorException("Respuesta JSON inválida de Koha al buscar patrones. URL: " + fullUrl + ", Response: " + response, e);
                 }
             }
 
             if (pageResults.length() > 0) {
                 for (int i = 0; i < pageResults.length(); i++) {
-                    allResults.put(pageResults.getJSONObject(i));
+                    try {
+                        allResults.put(pageResults.getJSONObject(i));
+                    } catch (JSONException e) {
+                         throw new ConnectorException("Error processing individual patron from search results. URL: " + fullUrl + ", Entry: " + pageResults.opt(i), e);
+                    }
                 }
             }
 
@@ -127,76 +145,6 @@ public class PatronService {
         return allResults;
     }
 
-    // --- Métodos de ayuda para ejecutar peticiones HTTP ---
-
-    private JSONObject callRequestWithEntity(HttpEntityEnclosingRequestBase request, JSONObject payload) throws IOException {
-        request.setHeader("Content-Type", "application/json");
-        request.setHeader("Accept", "application/json");
-        if (payload != null) {
-            request.setEntity(new ByteArrayEntity(payload.toString().getBytes(StandardCharsets.UTF_8)));
-        }
-
-        try (CloseableHttpResponse response = httpClient.execute(request)) {
-            processResponseErrors(response);
-            String result = EntityUtils.toString(response.getEntity(), StandardCharsets.UTF_8);
-            if (response.getStatusLine().getStatusCode() == 204 || StringUtil.isBlank(result)) {
-                return new JSONObject();
-            }
-            return new JSONObject(result);
-        } catch (JSONException e) {
-            throw new ConnectorException("Fallo al parsear respuesta JSON para " + request.getURI(), e);
-        }
-    }
-
-    private String callRequest(HttpRequestBase request) throws IOException {
-        request.setHeader("Accept", "application/json");
-        request.setHeader("Accept-Encoding", "gzip");
-
-        try (CloseableHttpResponse response = httpClient.execute(request)) {
-            processResponseErrors(response);
-            HttpEntity entity = response.getEntity();
-
-            // --- CORRECCIÓN APLICADA ---
-            if (entity == null) {
-                return ""; // Devolver un string vacío si no hay cuerpo de respuesta
-            }
-
-            InputStream inputStream = entity.getContent();
-            Header contentEncoding = entity.getContentEncoding();
-            if (contentEncoding != null && "gzip".equalsIgnoreCase(contentEncoding.getValue())) {
-                inputStream = new GZIPInputStream(inputStream);
-            }
-            return new String(inputStream.readAllBytes(), StandardCharsets.UTF_8);
-        }
-    }
-
-    private void processResponseErrors(CloseableHttpResponse response) throws ConnectorIOException {
-        int statusCode = response.getStatusLine().getStatusCode();
-        if (statusCode >= 200 && statusCode < 300) {
-            return; // Sin error
-        }
-
-        String body = "";
-        try {
-            HttpEntity entity = response.getEntity();
-            if (entity != null) {
-                body = EntityUtils.toString(entity);
-            }
-        } catch (IOException e) {
-            // No hacer nada, el error principal es el status code
-        }
-
-        LOG.error("Error en la respuesta HTTP. Status: {0}, Razón: {1}, Cuerpo: {2}",
-                statusCode, response.getStatusLine().getReasonPhrase(), body);
-
-        throw new ConnectorIOException("Error en la API de Koha. Status: " + statusCode + " " + response.getStatusLine().getReasonPhrase());
-    }
-
-    private String urlEncodeUTF8(String s) {
-        try {
-            return URLEncoder.encode(s, StandardCharsets.UTF_8.name());
-        } catch (UnsupportedEncodingException e) {
-            throw new ConnectorException("La codificación UTF-8 no está soportada, esto no debería ocurrir.", e);
-        }
-    }
+    // Removed duplicated helper methods: callRequestWithEntity, callRequest, processResponseErrors, urlEncodeUTF8
+    // They are now inherited from AbstractKohaService.
 }

--- a/src/test/java/com/identicum/connectors/KohaFilterTranslatorTest.java
+++ b/src/test/java/com/identicum/connectors/KohaFilterTranslatorTest.java
@@ -1,0 +1,122 @@
+package com.identicum.connectors;
+
+import org.identityconnectors.framework.common.objects.AttributeBuilder;
+import org.identityconnectors.framework.common.objects.Name;
+import org.identityconnectors.framework.common.objects.Uid;
+import org.identityconnectors.framework.common.objects.filter.EqualsFilter;
+import org.identityconnectors.framework.common.objects.filter.Filter;
+    import org.identityconnectors.framework.common.objects.filter.FilterBuilder;
+// Importa otros tipos de filtro si los vas a probar, ej. AndFilter, OrFilter
+// import org.identityconnectors.framework.common.objects.filter.GreaterThanFilter;
+import org.junit.jupiter.api.Test;
+    import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class KohaFilterTranslatorTest {
+
+    private final KohaFilterTranslator translator = new KohaFilterTranslator();
+
+    @Test
+    void testTranslateEqualsFilter_Uid() {
+        Filter filter = new EqualsFilter(new Uid("12345"));
+        List<KohaFilter> kohaFilters = translator.translate(filter);
+        assertNotNull(kohaFilters, "La lista de KohaFilter no debería ser null");
+        assertFalse(kohaFilters.isEmpty(), "La lista de KohaFilter no debería estar vacía para Uid");
+        KohaFilter kohaFilter = kohaFilters.get(0);
+        assertEquals("12345", kohaFilter.getByUid());
+        assertNull(kohaFilter.getByName());
+        assertNull(kohaFilter.getByEmail());
+        assertNull(kohaFilter.getByCardNumber());
+    }
+
+    @Test
+    void testTranslateEqualsFilter_Name() {
+        // Name.NAME en ConnId se mapea a 'userid' en Koha para patrones (según KohaFilter)
+        Filter filter = new EqualsFilter(new Name("jdoe"));
+        List<KohaFilter> kohaFilters = translator.translate(filter);
+        assertNotNull(kohaFilters, "La lista de KohaFilter no debería ser null");
+        assertFalse(kohaFilters.isEmpty(), "La lista de KohaFilter no debería estar vacía para Name");
+        KohaFilter kohaFilter = kohaFilters.get(0);
+        assertEquals("jdoe", kohaFilter.getByName());
+        assertNull(kohaFilter.getByUid());
+        assertNull(kohaFilter.getByEmail());
+        assertNull(kohaFilter.getByCardNumber());
+    }
+
+    @Test
+    void testTranslateEqualsFilter_Email() {
+        Filter filter = new EqualsFilter(AttributeBuilder.build("email", "jdoe@example.com"));
+        List<KohaFilter> kohaFilters = translator.translate(filter);
+        assertNotNull(kohaFilters, "La lista de KohaFilter no debería ser null");
+        assertFalse(kohaFilters.isEmpty(), "La lista de KohaFilter no debería estar vacía para email");
+        KohaFilter kohaFilter = kohaFilters.get(0);
+        assertEquals("jdoe@example.com", kohaFilter.getByEmail());
+        assertNull(kohaFilter.getByUid());
+        assertNull(kohaFilter.getByName());
+        assertNull(kohaFilter.getByCardNumber());
+    }
+
+    @Test
+    void testTranslateEqualsFilter_CardNumber() {
+        Filter filter = new EqualsFilter(AttributeBuilder.build("cardnumber", "C123"));
+        List<KohaFilter> kohaFilters = translator.translate(filter);
+        assertNotNull(kohaFilters, "La lista de KohaFilter no debería ser null");
+        assertFalse(kohaFilters.isEmpty(), "La lista de KohaFilter no debería estar vacía para cardnumber");
+        KohaFilter kohaFilter = kohaFilters.get(0);
+        assertEquals("C123", kohaFilter.getByCardNumber());
+        assertNull(kohaFilter.getByUid());
+        assertNull(kohaFilter.getByName());
+        assertNull(kohaFilter.getByEmail());
+    }
+
+    @Test
+    void testTranslateUnsupportedEqualsAttribute() {
+        // El traductor devuelve null para atributos no mapeados en EqualsFilter.
+        Filter filter = new EqualsFilter(AttributeBuilder.build("unsupported_attr", "value"));
+        List<KohaFilter> kohaFilters = translator.translate(filter);
+        // AbstractFilterTranslator.translate puede devolver una lista vacía o null
+        // si createEqualsExpression devuelve null.
+        assertTrue(kohaFilters == null || kohaFilters.isEmpty(),
+                   "La lista de KohaFilter debería ser null o vacía para un atributo no soportado en EqualsFilter");
+    }
+
+    @Test
+    void testTranslateNotEqualsFilter() {
+        // NotFilter no está soportado explícitamente y debería resultar en null
+        // porque createEqualsExpression devuelve null si not=true
+        Filter filter = FilterBuilder.not(new EqualsFilter(new Uid("12345")));
+        List<KohaFilter> kohaFilters = translator.translate(filter);
+        assertTrue(kohaFilters == null || kohaFilters.isEmpty(),
+                   "La lista de KohaFilter debería ser null o vacía para un NotFilter");
+    }
+
+    @Test
+    void testTranslateNullConnIdFilter() {
+        // El método translate de AbstractFilterTranslator devuelve una lista vacía si el filtro es null.
+        List<KohaFilter> kohaFilters = translator.translate(null);
+        assertNotNull(kohaFilters, "La lista de KohaFilter no debería ser null para un filtro ConnId null");
+        assertTrue(kohaFilters.isEmpty(), "La lista de KohaFilter debería estar vacía para un filtro ConnId null");
+    }
+
+    @Test
+    void testTranslateEqualsFilter_NullValue() {
+        // El traductor devuelve null si el valor del atributo es null
+        Filter filter = new EqualsFilter(AttributeBuilder.build("email", (Object)null));
+        List<KohaFilter> kohaFilters = translator.translate(filter);
+        assertTrue(kohaFilters == null || kohaFilters.isEmpty(),
+                   "La lista de KohaFilter debería ser null o vacía para un atributo con valor null");
+    }
+
+    // Ejemplo de prueba para un tipo de filtro completamente no soportado por AbstractFilterTranslator
+    // Esto es solo para ilustrar, ya que AbstractFilterTranslator solo llama a createEqualsExpression
+    // para EqualsFilter. Otros tipos de filtro resultarán en null por defecto.
+    /*
+    @Test
+    void testTranslateCompletelyUnsupportedFilterType() {
+        Filter filter = new GreaterThanFilter(AttributeBuilder.build("some_attr", 10));
+        KohaFilter kohaFilter = translator.translate(filter);
+        assertNull(kohaFilter, "KohaFilter debería ser null para un tipo de filtro no soportado");
+    }
+    */
+}

--- a/src/test/java/com/identicum/connectors/mappers/BaseMapperTest.java
+++ b/src/test/java/com/identicum/connectors/mappers/BaseMapperTest.java
@@ -1,0 +1,113 @@
+package com.identicum.connectors.mappers;
+
+import com.identicum.connectors.model.AttributeMetadata;
+import org.identityconnectors.framework.common.exceptions.InvalidAttributeValueException;
+import org.json.JSONObject;
+import org.junit.jupiter.api.Test; // JUnit 5
+import static org.junit.jupiter.api.Assertions.*; // JUnit 5 Assertions
+
+import java.time.LocalDate;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
+
+public class BaseMapperTest {
+
+    // Instancia anónima para probar los métodos protected de BaseMapper
+    private final BaseMapper mapper = new BaseMapper() {};
+
+    // === Pruebas para convertConnIdValueToKohaJsonValue ===
+
+    @Test
+    void testConnIdStringConversion() {
+        AttributeMetadata meta = new AttributeMetadata("testString", "kohaString", String.class);
+        assertEquals("hello", mapper.convertConnIdValueToKohaJsonValue("hello", meta));
+    }
+
+    @Test
+    void testConnIdBooleanConversion() {
+        AttributeMetadata meta = new AttributeMetadata("testBool", "kohaBool", Boolean.class);
+        assertEquals(true, mapper.convertConnIdValueToKohaJsonValue(true, meta));
+        assertEquals(false, mapper.convertConnIdValueToKohaJsonValue(false, meta));
+    }
+
+    @Test
+    void testConnIdIntegerConversion() {
+        AttributeMetadata meta = new AttributeMetadata("testInt", "kohaInt", Integer.class);
+        assertEquals(123, mapper.convertConnIdValueToKohaJsonValue(123, meta));
+    }
+
+    @Test
+    void testConnIdNullConversion() {
+        AttributeMetadata meta = new AttributeMetadata("testNull", "kohaNull", String.class);
+        assertEquals(JSONObject.NULL, mapper.convertConnIdValueToKohaJsonValue(null, meta));
+    }
+
+    @Test
+    void testConnIdDateConversion_Valid() {
+        AttributeMetadata metaDate = new AttributeMetadata("date_of_birth", "date_of_birth", String.class);
+        assertEquals("2023-01-15", mapper.convertConnIdValueToKohaJsonValue("2023-01-15", metaDate));
+    }
+
+    @Test
+    void testConnIdDateConversion_Invalid() {
+        AttributeMetadata metaDate = new AttributeMetadata("date_of_birth", "date_of_birth", String.class);
+        Exception exception = assertThrows(InvalidAttributeValueException.class, () -> {
+            mapper.convertConnIdValueToKohaJsonValue("15/01/2023", metaDate);
+        });
+        assertTrue(exception.getMessage().contains("Formato de fecha inválido '15/01/2023'"));
+    }
+
+    // === Pruebas para convertKohaValueToConnIdValue ===
+
+    @Test
+    void testKohaStringConversion() {
+        AttributeMetadata meta = new AttributeMetadata("testString", "kohaString", String.class);
+        assertEquals("kohaValue", mapper.convertKohaValueToConnIdValue("kohaValue", meta));
+    }
+
+    @Test
+    void testKohaBooleanConversion() {
+        AttributeMetadata meta = new AttributeMetadata("testBool", "kohaBool", Boolean.class);
+        assertEquals(true, mapper.convertKohaValueToConnIdValue(true, meta));
+        assertEquals(false, mapper.convertKohaValueToConnIdValue(false, meta));
+        assertEquals(true, mapper.convertKohaValueToConnIdValue("1", meta));
+        assertEquals(false, mapper.convertKohaValueToConnIdValue("0", meta));
+        assertEquals(true, mapper.convertKohaValueToConnIdValue("True", meta));
+        assertEquals(false, mapper.convertKohaValueToConnIdValue("False", meta));
+    }
+
+    @Test
+    void testKohaIntegerConversion() {
+        AttributeMetadata meta = new AttributeMetadata("testInt", "kohaInt", Integer.class);
+        assertEquals(456, mapper.convertKohaValueToConnIdValue(456, meta));
+        assertEquals(789, mapper.convertKohaValueToConnIdValue("789", meta));
+    }
+
+    @Test
+    void testKohaNullConversion() {
+        AttributeMetadata meta = new AttributeMetadata("testNull", "kohaNull", String.class);
+        assertNull(mapper.convertKohaValueToConnIdValue(null, meta));
+        assertNull(mapper.convertKohaValueToConnIdValue(JSONObject.NULL, meta));
+    }
+
+    @Test
+    void testKohaDateConversion_Valid() {
+        AttributeMetadata metaDate = new AttributeMetadata("date_of_birth", "date_of_birth", String.class);
+        assertEquals("2023-03-20", mapper.convertKohaValueToConnIdValue("2023-03-20", metaDate));
+    }
+
+    @Test
+    void testKohaDateConversion_InvalidFormat() {
+        AttributeMetadata metaDate = new AttributeMetadata("date_of_birth", "date_of_birth", String.class);
+        // BaseMapper.convertKohaValueToConnIdValue logs a warning and returns null for parse errors
+        assertNull(mapper.convertKohaValueToConnIdValue("20-03-2023", metaDate));
+    }
+
+    @Test
+    void testKohaDateTimeConversion_Valid() {
+        AttributeMetadata metaDateTime = new AttributeMetadata("updated_on", "updated_on", String.class);
+        String kohaDateTime = "2023-03-20T10:30:00+02:00";
+        // Should parse and reformat to ISO_OFFSET_DATE_TIME string (which it already is)
+        assertEquals(kohaDateTime, mapper.convertKohaValueToConnIdValue(kohaDateTime, metaDateTime));
+    }
+}

--- a/src/test/java/com/identicum/connectors/mappers/CategoryMapperTest.java
+++ b/src/test/java/com/identicum/connectors/mappers/CategoryMapperTest.java
@@ -1,0 +1,143 @@
+package com.identicum.connectors.mappers;
+
+import org.identityconnectors.framework.common.objects.*;
+import org.json.JSONObject;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class CategoryMapperTest {
+
+    private CategoryMapper categoryMapper;
+    private static final String TEST_UID = "C1";
+    private static final String TEST_CATEGORY_NAME = "Adults"; // ConnId Name
+    private static final String TEST_CATEGORY_KOHA_NAME = "Adult Patrons"; // Koha's 'description' field
+    private static final String TEST_CATEGORY_TYPE = "A";
+    private static final Integer TEST_ENROLMENT_PERIOD = 12; // months
+
+    @BeforeEach
+    void setUp() {
+        categoryMapper = new CategoryMapper();
+    }
+
+    private Set<Attribute> buildSampleAttributesForCreate() {
+        Set<Attribute> attributes = new HashSet<>();
+        // El atributo Name de ConnId se mapea al 'description' de Koha para categorías
+        attributes.add(AttributeBuilder.build(Name.NAME, TEST_CATEGORY_KOHA_NAME));
+        attributes.add(AttributeBuilder.build("category_type", TEST_CATEGORY_TYPE));
+        attributes.add(AttributeBuilder.build("enrolment_period", TEST_ENROLMENT_PERIOD));
+        return attributes;
+    }
+
+    private Set<Attribute> buildSampleAttributesForUpdate() {
+        Set<Attribute> attributes = new HashSet<>();
+        attributes.add(AttributeBuilder.build("enrolment_period", 24));
+        return attributes;
+    }
+
+    @Test
+    void testBuildCategoryJson_Create() {
+        Set<Attribute> attributes = buildSampleAttributesForCreate();
+        JSONObject json = categoryMapper.buildCategoryJson(attributes, true);
+
+        assertNotNull(json);
+        // 'name' (ConnId) se mapea a 'description' (Koha)
+        assertEquals(TEST_CATEGORY_KOHA_NAME, json.getString("description"));
+        assertEquals(TEST_CATEGORY_TYPE, json.getString("category_type"));
+        assertEquals(TEST_ENROLMENT_PERIOD, json.getInt("enrolment_period_in_months"));
+
+        // Atributos no creables no deben estar
+        assertFalse(json.has("min_password_length"));
+        assertFalse(json.has(CategoryMapper.KOHA_CATEGORY_ID_NATIVE_NAME));
+    }
+
+    @Test
+    void testBuildCategoryJson_Update() {
+        Set<Attribute> attributes = buildSampleAttributesForUpdate();
+        JSONObject json = categoryMapper.buildCategoryJson(attributes, false);
+
+        assertNotNull(json);
+        assertEquals(24, json.getInt("enrolment_period_in_months"));
+
+        assertFalse(json.has("description")); // No se envió 'name' para actualizar
+        assertFalse(json.has("min_password_length"));
+    }
+
+    @Test
+    void testConvertJsonToCategoryObject_Basic() {
+        JSONObject kohaJson = new JSONObject();
+        kohaJson.put(CategoryMapper.KOHA_CATEGORY_ID_NATIVE_NAME, TEST_UID);
+        // Koha usa 'description' para el nombre de la categoría
+        kohaJson.put("description", TEST_CATEGORY_KOHA_NAME);
+        kohaJson.put("category_type", TEST_CATEGORY_TYPE);
+        kohaJson.put("enrolment_period_in_months", TEST_ENROLMENT_PERIOD);
+        // Atributo no creable/actualizable pero leíble
+        kohaJson.put("min_password_length", 8);
+
+        ConnectorObject co = categoryMapper.convertJsonToCategoryObject(kohaJson);
+
+        assertNotNull(co);
+        assertEquals(TEST_UID, co.getUid().getUidValue());
+        // __NAME__ debe ser el valor de 'description' de Koha
+        assertEquals(TEST_CATEGORY_KOHA_NAME, co.getName().getNameValue());
+
+        assertEquals(TEST_CATEGORY_TYPE, AttributeUtil.getStringValue(co.getAttributeByName("category_type")));
+        assertEquals(TEST_ENROLMENT_PERIOD, AttributeUtil.getIntegerValue(co.getAttributeByName("enrolment_period")));
+        assertEquals(Integer.valueOf(8), AttributeUtil.getIntegerValue(co.getAttributeByName("min_password_length")));
+    }
+
+    @Test
+    void testConvertJsonToCategoryObject_NameMapping() {
+        // Prueba específica para asegurar que el Name.NAME de ConnId (que es __NAME__)
+        // se mapea correctamente desde/hacia 'description' de Koha.
+        // Y que el atributo 'name' de AttributeMetadata (que es el ConnId 'name') también lo hace.
+
+        // 1. ConnId Attrs -> JSON
+        Set<Attribute> attrsToKoha = new HashSet<>();
+        attrsToKoha.add(AttributeBuilder.build(Name.NAME, "Special Category Name"));
+        JSONObject jsonToKoha = categoryMapper.buildCategoryJson(attrsToKoha, true);
+        assertEquals("Special Category Name", jsonToKoha.getString("description"));
+
+        // 2. JSON -> ConnId Object
+        JSONObject jsonFromKoha = new JSONObject();
+        jsonFromKoha.put(CategoryMapper.KOHA_CATEGORY_ID_NATIVE_NAME, "C2");
+        jsonFromKoha.put("description", "Another Category Name");
+        ConnectorObject coFromKoha = categoryMapper.convertJsonToCategoryObject(jsonFromKoha);
+        assertEquals("Another Category Name", coFromKoha.getName().getNameValue());
+        // También verificamos que el atributo 'name' (si se pidiera explícitamente) tendría el mismo valor
+        assertEquals("Another Category Name", AttributeUtil.getStringValue(coFromKoha.getAttributeByName("name")));
+    }
+
+
+    @Test
+    void testConvertJsonToCategoryObject_NullAndMissingAttributes() {
+        JSONObject kohaJson = new JSONObject();
+        kohaJson.put(CategoryMapper.KOHA_CATEGORY_ID_NATIVE_NAME, TEST_UID);
+        kohaJson.put("description", TEST_CATEGORY_KOHA_NAME);
+        // category_type es omitido
+        kohaJson.put("enrolment_period_in_months", JSONObject.NULL);
+
+        ConnectorObject co = categoryMapper.convertJsonToCategoryObject(kohaJson);
+
+        assertNotNull(co);
+        assertEquals(TEST_UID, co.getUid().getUidValue());
+        assertEquals(TEST_CATEGORY_KOHA_NAME, co.getName().getNameValue());
+
+        assertNull(co.getAttributeByName("category_type"));
+        assertNull(co.getAttributeByName("enrolment_period"));
+    }
+
+    @Test
+    void testConvertJsonToCategoryObject_NoUid() {
+        JSONObject kohaJson = new JSONObject();
+        kohaJson.put("description", TEST_CATEGORY_KOHA_NAME);
+        // Falta KOHA_CATEGORY_ID_NATIVE_NAME
+
+        ConnectorObject co = categoryMapper.convertJsonToCategoryObject(kohaJson);
+        assertNull(co);
+    }
+}

--- a/src/test/java/com/identicum/connectors/mappers/PatronMapperTest.java
+++ b/src/test/java/com/identicum/connectors/mappers/PatronMapperTest.java
@@ -1,0 +1,157 @@
+package com.identicum.connectors.mappers;
+
+import com.identicum.connectors.model.AttributeMetadata;
+import org.identityconnectors.framework.common.objects.*;
+import org.json.JSONObject;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class PatronMapperTest {
+
+    private PatronMapper patronMapper;
+    private static final String TEST_UID = "123";
+    private static final String TEST_USERID = "testuser";
+    private static final String TEST_SURNAME = "Doe";
+    private static final String TEST_FIRSTNAME = "John";
+    private static final String TEST_CARDNUMBER = "C123456";
+    private static final String TEST_LIBRARY_ID = "MAIN";
+    private static final String TEST_CATEGORY_ID = "ADULT";
+    private static final String TEST_EMAIL = "john.doe@example.com";
+
+
+    @BeforeEach
+    void setUp() {
+        patronMapper = new PatronMapper();
+        // Asegurar que los metadatos estén cargados si PatronMapper depende de inicialización estática
+        // y las pruebas se ejecutan de forma que el static block no se haya ejecutado.
+        // En este caso, PatronMapper.ATTRIBUTE_METADATA_MAP es estático y se inicializa una vez.
+    }
+
+    private Set<Attribute> buildSampleAttributesForCreate() {
+        Set<Attribute> attributes = new HashSet<>();
+        attributes.add(AttributeBuilder.build("userid", TEST_USERID)); // Name attribute via 'userid'
+        attributes.add(AttributeBuilder.build("surname", TEST_SURNAME));
+        attributes.add(AttributeBuilder.build("firstname", TEST_FIRSTNAME));
+        attributes.add(AttributeBuilder.build("cardnumber", TEST_CARDNUMBER));
+        attributes.add(AttributeBuilder.build("library_id", TEST_LIBRARY_ID));
+        attributes.add(AttributeBuilder.build("category_id", TEST_CATEGORY_ID));
+        attributes.add(AttributeBuilder.build(OperationalAttributes.ENABLE_NAME, true)); // Ejemplo de atributo operacional
+        return attributes;
+    }
+
+    private Set<Attribute> buildSampleAttributesForUpdate() {
+        Set<Attribute> attributes = new HashSet<>();
+        attributes.add(AttributeBuilder.build("email", TEST_EMAIL));
+        attributes.add(AttributeBuilder.build("phone", "123-456-7890"));
+        return attributes;
+    }
+
+    @Test
+    void testBuildPatronJson_Create() {
+        Set<Attribute> attributes = buildSampleAttributesForCreate();
+        JSONObject json = patronMapper.buildPatronJson(attributes, true);
+
+        assertNotNull(json);
+        assertEquals(TEST_USERID, json.getString("userid"));
+        assertEquals(TEST_SURNAME, json.getString("surname"));
+        assertEquals(TEST_FIRSTNAME, json.getString("firstname"));
+        assertEquals(TEST_CARDNUMBER, json.getString("cardnumber"));
+        assertEquals(TEST_LIBRARY_ID, json.getString("library_id"));
+        assertEquals(TEST_CATEGORY_ID, json.getString("category_id"));
+
+        // Atributos no creables no deben estar
+        assertFalse(json.has("date_enrolled"));
+        assertFalse(json.has(PatronMapper.KOHA_PATRON_ID_NATIVE_NAME)); // UID no se envía en create
+    }
+
+    @Test
+    void testBuildPatronJson_Update() {
+        Set<Attribute> attributes = buildSampleAttributesForUpdate();
+        JSONObject json = patronMapper.buildPatronJson(attributes, false);
+
+        assertNotNull(json);
+        assertEquals(TEST_EMAIL, json.getString("email"));
+        assertEquals("123-456-7890", json.getString("phone"));
+
+        // Atributos no actualizables no deben estar, y tampoco los no enviados
+        assertFalse(json.has("userid"));
+        assertFalse(json.has("date_enrolled"));
+    }
+
+    @Test
+    void testBuildPatronJson_ClearAttributeOnUpdate() {
+        Set<Attribute> attributes = new HashSet<>();
+        // Enviar null para borrar el atributo 'firstname'
+        attributes.add(AttributeBuilder.build("firstname", (Object) null));
+        JSONObject json = patronMapper.buildPatronJson(attributes, false);
+
+        assertNotNull(json);
+        assertTrue(json.has("firstname"));
+        assertEquals(JSONObject.NULL, json.get("firstname"));
+    }
+
+    @Test
+    void testConvertJsonToPatronObject_Basic() {
+        JSONObject kohaJson = new JSONObject();
+        kohaJson.put(PatronMapper.KOHA_PATRON_ID_NATIVE_NAME, TEST_UID);
+        kohaJson.put("userid", TEST_USERID);
+        kohaJson.put("surname", TEST_SURNAME);
+        kohaJson.put("firstname", TEST_FIRSTNAME);
+        kohaJson.put("cardnumber", TEST_CARDNUMBER);
+        kohaJson.put("library_id", TEST_LIBRARY_ID);
+        kohaJson.put("category_id", TEST_CATEGORY_ID);
+        kohaJson.put("email", TEST_EMAIL);
+        kohaJson.put("date_enrolled", "2023-01-01"); // Atributo no creable/actualizable pero leíble
+
+        ConnectorObject co = patronMapper.convertJsonToPatronObject(kohaJson);
+
+        assertNotNull(co);
+        assertEquals(TEST_UID, co.getUid().getUidValue());
+        assertEquals(TEST_USERID, co.getName().getNameValue()); // __NAME__
+
+        assertEquals(TEST_SURNAME, AttributeUtil.getStringValue(co.getAttributeByName("surname")));
+        assertEquals(TEST_FIRSTNAME, AttributeUtil.getStringValue(co.getAttributeByName("firstname")));
+        assertEquals(TEST_CARDNUMBER, AttributeUtil.getStringValue(co.getAttributeByName("cardnumber")));
+        assertEquals(TEST_LIBRARY_ID, AttributeUtil.getStringValue(co.getAttributeByName("library_id")));
+        assertEquals(TEST_CATEGORY_ID, AttributeUtil.getStringValue(co.getAttributeByName("category_id")));
+        assertEquals(TEST_EMAIL, AttributeUtil.getStringValue(co.getAttributeByName("email")));
+        assertEquals("2023-01-01", AttributeUtil.getStringValue(co.getAttributeByName("date_enrolled")));
+    }
+
+    @Test
+    void testConvertJsonToPatronObject_NullAndMissingAttributes() {
+        JSONObject kohaJson = new JSONObject();
+        kohaJson.put(PatronMapper.KOHA_PATRON_ID_NATIVE_NAME, TEST_UID);
+        kohaJson.put("userid", TEST_USERID);
+        kohaJson.put("surname", TEST_SURNAME);
+        // firstname es omitido
+        kohaJson.put("email", JSONObject.NULL); // email es explícitamente null
+
+        ConnectorObject co = patronMapper.convertJsonToPatronObject(kohaJson);
+
+        assertNotNull(co);
+        assertEquals(TEST_UID, co.getUid().getUidValue());
+        assertEquals(TEST_USERID, co.getName().getNameValue());
+        assertEquals(TEST_SURNAME, AttributeUtil.getStringValue(co.getAttributeByName("surname")));
+
+        assertNull(co.getAttributeByName("firstname")); // No debería estar presente
+        assertNull(co.getAttributeByName("email"));     // Debería ser null o no estar presente
+    }
+
+    @Test
+    void testConvertJsonToPatronObject_NoUid() {
+        JSONObject kohaJson = new JSONObject();
+        kohaJson.put("userid", TEST_USERID);
+        kohaJson.put("surname", TEST_SURNAME);
+        // Falta KOHA_PATRON_ID_NATIVE_NAME
+
+        ConnectorObject co = patronMapper.convertJsonToPatronObject(kohaJson);
+        assertNull(co); // Debería retornar null según la lógica del mapper
+    }
+}


### PR DESCRIPTION
Este commit introduce una serie de mejoras significativas al conector de Koha para Midpoint, enfocándose en la robustez, mantenibilidad, manejo de errores, logging y pruebas.

Mejoras Principales:

1.  **Actualización de Dependencias:**
    *   `com.evolveum.polygon:connector-parent` actualizado a `1.5.2.0`.
    *   `com.evolveum.polygon:connector-rest` actualizado a `1.5.2.0`.
    *   `org.json:json` actualizado a `20250517`.
    *   Añadida dependencia explícita a `org.apache.httpcomponents:httpclient:4.5.14` para resolver problemas de compilación.

2.  **Validación de Configuración Mejorada:**
    *   He añadido validaciones explícitas en `KohaConnector.init` para parámetros cruciales como `serviceAddress`, `authMethod`, y las credenciales correspondientes (username/password para BASIC, clientId/clientSecret para OAUTH2).

3.  **Manejo de Errores Avanzado:**
    *   Introduje una clase base `AbstractKohaService` que centraliza la lógica de comunicación HTTP.
    *   Manejo robusto de errores de red (ej. `HttpHostConnectException`, `SocketTimeoutException`) y errores de respuesta HTTP (4xx, 5xx), mapeándolos a excepciones ConnId específicas (`ConnectionFailedException`, `UnknownUidException`, `PermissionDeniedException`, `AlreadyExistsException`, `InvalidAttributeValueException`).
    *   `PatronService` y `CategoryService` ahora extienden `AbstractKohaService`, heredando el manejo de errores mejorado.

4.  **Refactorización para Claridad y Mantenibilidad:**
    *   Reduje la duplicación de código en la definición del esquema en `KohaConnector` mediante un método helper (`buildObjectClassInfo`).
    *   La lógica común de los servicios HTTP se consolidó en `AbstractKohaService`.

5.  **Logging Detallado y Refinado:**
    *   Mejoré significativamente el logging en todas las capas:
        *   `KohaConnector`: Logs de inicio/fin para operaciones CRUD y de búsqueda.
        *   `AbstractKohaService`: Nivel DEBUG para trazas de solicitudes HTTP, nivel TRACE para payloads de solicitud y cuerpos de respuesta.
        *   Mappers (`BaseMapper`, `PatronMapper`, `CategoryMapper`): Logging OK y TRACE para seguir la transformación de datos.
    *   Corregí las llamadas a la API de logging de ConnId para usar los métodos disponibles (`LOG.ok`, `LOG.info`).

6.  **Gestión de Recursos Fortalecida:**
    *   El método `init` de `KohaConnector` ahora asegura que el `CloseableHttpClient` se cierre si ocurre un error después de su creación pero antes de que la inicialización se complete.

7.  **Método de Verificación Expandido:**
    *   El método de verificación en `KohaConnector` ahora no solo comprueba la conectividad básica, sino también la correcta inicialización y obtención del esquema del conector.

8.  **Correcciones y Mejoras en Mappers:**
    *   Corregí un problema en `CategoryMapper` para asegurar que el atributo `name` (mapeado a `description`) se maneje consistentemente.
    *   Ajusté la conversión de `ZonedDateTime` a String en `BaseMapper` para asegurar un formato de salida consistente.

9.  **Introducción de Pruebas Unitarias:**
    *   Añadí 33 pruebas unitarias utilizando JUnit 5, cubriendo:
        *   `BaseMapper` (conversión de tipos de datos).
        *   `PatronMapper` (transformación de atributos de patrón).
        *   `CategoryMapper` (transformación de atributos de categoría).
        *   `KohaFilterTranslator` (traducción de filtros ConnId).
    *   Estas pruebas ayudaron a identificar y corregir varios problemas de compilación y comportamiento.

10. **Documentación Actualizada:**
    *   El archivo `README.md` se actualizó para reflejar los cambios en la arquitectura (mención de `AbstractKohaService`), destacar las mejoras generales y añadir una sección de "Troubleshooting" con instrucciones para habilitar el logging detallado.

11. **Correcciones de Build y Código Menores:**
    *   Resolví el uso de `AttributeUtil.toMultivaluedMap` que causaba errores.
    *   Apliqué una solución temporal para un problema de compilación con `ConnectorRuntimeException` (cambiándolo a `RuntimeException` en un único punto en `AbstractKohaService`) para permitir que las pruebas de los mappers compilaran y se ejecutaran. Esto podría indicar un problema subyacente con las dependencias transitivas o el classpath que podría requerir investigación futura.