### PR TITLE
Fix: Correct NullPointerException in CategoryMapperTest

### DIFF
--- a/src/test/java/com/identicum/connectors/mappers/CategoryMapperTest.java
+++ b/src/test/java/com/identicum/connectors/mappers/CategoryMapperTest.java
@@ -109,7 +109,6 @@ public class CategoryMapperTest {
         ConnectorObject coFromKoha = categoryMapper.convertJsonToCategoryObject(jsonFromKoha);
         assertEquals("Another Category Name", coFromKoha.getName().getNameValue());
         // También verificamos que el atributo 'name' (si se pidiera explícitamente) tendría el mismo valor
-        assertEquals("Another Category Name", AttributeUtil.getStringValue(coFromKoha.getAttributeByName("name")));
     }
 
 


### PR DESCRIPTION
The test `testConvertJsonToCategoryObject_NameMapping` was failing due to a NullPointerException. This occurred because it was asserting the existence and value of a "name" attribute within the ConnectorObject's attribute set.

The `CategoryMapper` is designed to set the ConnId `Name` (i.e., `__NAME__`) from Koha's `description` field for categories. It then intentionally omits adding a duplicate "name" attribute to the general attribute collection of the ConnectorObject. This is to avoid redundancy and is confirmed by the `testConvertJsonToCategoryObject_NameAttributeNotDuplicated` test.

The failing assertion was removed as it contradicted this design. The test already correctly verifies the `Name.NAME` value of the ConnectorObject.