### PR TITLE
Remove outdated comments

### DIFF
--- a/src/main/java/com/identicum/connectors/KohaFilter.java
+++ b/src/main/java/com/identicum/connectors/KohaFilter.java
@@ -22,7 +22,7 @@ public class KohaFilter {
     void setByCardNumber(String byCardNumber) { this.byCardNumber = byCardNumber; }
 
     public boolean hasCriteria() {
-        return byUid != null || byName != null || byEmail != null || byCardNumber != null; // <-- ACTUALIZAR ESTA LÍNEA
+        return byUid != null || byName != null || byEmail != null || byCardNumber != null;
     }
 
     @Override

--- a/src/main/java/com/identicum/connectors/KohaFilterTranslator.java
+++ b/src/main/java/com/identicum/connectors/KohaFilterTranslator.java
@@ -43,7 +43,6 @@ public class KohaFilterTranslator extends AbstractFilterTranslator<KohaFilter> {
             LOG.ok("Translated EqualsFilter on Name.NAME to KohaFilter.byName: {0}", singleValue);
             handled = true;
 
-            // --- INICIO DE LA CORRECCIÓN ---
             // Se reemplaza la referencia a la constante por el nombre del atributo en texto plano.
         } else if ("email".equals(attrName)) { // Filtro por email
             translatedFilter.setByEmail(singleValue);
@@ -57,7 +56,6 @@ public class KohaFilterTranslator extends AbstractFilterTranslator<KohaFilter> {
             LOG.ok("Translated EqualsFilter on 'cardnumber' to KohaFilter.byCardNumber: {0}", singleValue);
             handled = true;
         }
-        // --- FIN DE LA CORRECCIÓN ---
 
         if (handled) {
             return translatedFilter;

--- a/src/main/java/com/identicum/connectors/services/CategoryService.java
+++ b/src/main/java/com/identicum/connectors/services/CategoryService.java
@@ -139,6 +139,4 @@ public class CategoryService extends AbstractKohaService {
         return allResults;
     }
 
-    // Removed duplicated helper methods: callRequestWithEntity, callRequest, processResponseErrors, urlEncodeUTF8
-    // They are now inherited from AbstractKohaService.
 }

--- a/src/main/java/com/identicum/connectors/services/PatronService.java
+++ b/src/main/java/com/identicum/connectors/services/PatronService.java
@@ -145,6 +145,4 @@ public class PatronService extends AbstractKohaService {
         return allResults;
     }
 
-    // Removed duplicated helper methods: callRequestWithEntity, callRequest, processResponseErrors, urlEncodeUTF8
-    // They are now inherited from AbstractKohaService.
 }


### PR DESCRIPTION
## Summary
- clean up leftover placeholder comments in Koha filter classes
- remove duplicated helper comments from service classes

## Testing
- `mvn -q test` *(fails: Could not transfer parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_68559146d53c8326813b256857b58644