### PR TITLE
Add Patron/Category service tests and connector integration tests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -54,13 +54,25 @@
 			<version>5.9.3</version>
 			<scope>test</scope>
 		</dependency>
-		<dependency>
-			<groupId>org.junit.jupiter</groupId>
-			<artifactId>junit-jupiter-engine</artifactId>
-			<version>5.9.3</version>
-			<scope>test</scope>
-		</dependency>
-	</dependencies>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <version>5.9.3</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <version>5.11.0</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-junit-jupiter</artifactId>
+            <version>5.11.0</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
 
 	<build>
 		<plugins>

--- a/src/test/java/com/identicum/connectors/KohaConnectorIntegrationTest.java
+++ b/src/test/java/com/identicum/connectors/KohaConnectorIntegrationTest.java
@@ -1,0 +1,61 @@
+package com.identicum.connectors;
+
+import com.identicum.connectors.services.CategoryService;
+import com.identicum.connectors.services.PatronService;
+import org.identityconnectors.common.security.GuardedString;
+import org.identityconnectors.framework.common.exceptions.ConnectorIOException;
+import org.json.JSONArray;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.lang.reflect.Field;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+public class KohaConnectorIntegrationTest {
+
+    @Mock
+    private PatronService patronService;
+    @Mock
+    private CategoryService categoryService;
+
+    private KohaConnector connector;
+
+    @BeforeEach
+    void setup() throws Exception {
+        connector = new KohaConnector();
+        KohaConfiguration cfg = new KohaConfiguration();
+        cfg.setServiceAddress("http://localhost");
+        cfg.setAuthenticationMethodStrategy("BASIC");
+        cfg.setUsername("u");
+        cfg.setPassword(new GuardedString("p".toCharArray()));
+        connector.init(cfg);
+        injectField(connector, "patronService", patronService);
+        injectField(connector, "categoryService", categoryService);
+    }
+
+    private static void injectField(Object target, String name, Object value) throws Exception {
+        Field f = target.getClass().getDeclaredField(name);
+        f.setAccessible(true);
+        f.set(target, value);
+    }
+
+    @Test
+    void testTestSuccessful() throws Exception {
+        when(patronService.searchPatrons(any(), any())).thenReturn(new JSONArray());
+        assertDoesNotThrow(() -> connector.test());
+        verify(patronService, times(1)).searchPatrons(any(), any());
+    }
+
+    @Test
+    void testTestPropagatesException() throws Exception {
+        when(patronService.searchPatrons(any(), any())).thenThrow(new ConnectorIOException("fail"));
+        assertThrows(ConnectorIOException.class, () -> connector.test());
+    }
+}

--- a/src/test/java/com/identicum/connectors/services/CategoryServiceTest.java
+++ b/src/test/java/com/identicum/connectors/services/CategoryServiceTest.java
@@ -1,0 +1,100 @@
+package com.identicum.connectors.services;
+
+import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.client.methods.HttpPost;
+import org.apache.http.client.methods.HttpPut;
+import org.apache.http.client.methods.HttpDelete;
+import org.apache.http.entity.ContentType;
+import org.apache.http.entity.StringEntity;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.StatusLine;
+import org.apache.http.HttpEntity;
+import org.json.JSONArray;
+import org.json.JSONObject;
+import org.identityconnectors.framework.common.objects.OperationOptionsBuilder;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import java.io.IOException;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+public class CategoryServiceTest {
+
+    @Mock
+    private CloseableHttpClient httpClient;
+
+    private CategoryService categoryService;
+
+    @BeforeEach
+    void setUp() {
+        categoryService = new CategoryService(httpClient, "http://localhost");
+    }
+
+    private CloseableHttpResponse prepareResponse(int status, String body) throws IOException {
+        CloseableHttpResponse response = mock(CloseableHttpResponse.class);
+        StatusLine statusLine = mock(StatusLine.class);
+        when(statusLine.getStatusCode()).thenReturn(status);
+        when(response.getStatusLine()).thenReturn(statusLine);
+        HttpEntity entity = body == null ? null : new StringEntity(body, ContentType.APPLICATION_JSON);
+        when(response.getEntity()).thenReturn(entity);
+        return response;
+    }
+
+    @Test
+    void testGetCategorySuccess() throws Exception {
+        CloseableHttpResponse resp = prepareResponse(200, "{\"category_id\":\"C1\"}");
+        when(httpClient.execute(any(HttpGet.class))).thenReturn(resp);
+
+        JSONObject obj = categoryService.getCategory("C1");
+        assertEquals("C1", obj.getString("category_id"));
+    }
+
+    @Test
+    void testCreateCategorySuccess() throws Exception {
+        CloseableHttpResponse resp = prepareResponse(200, "{\"category_id\":\"C2\"}");
+        when(httpClient.execute(any(HttpPost.class))).thenReturn(resp);
+
+        JSONObject payload = new JSONObject().put("description", "Adults");
+        JSONObject created = categoryService.createCategory(payload);
+        assertEquals("C2", created.getString("category_id"));
+    }
+
+    @Test
+    void testUpdateCategorySuccess() throws Exception {
+        CloseableHttpResponse resp = prepareResponse(200, "{}");
+        when(httpClient.execute(any(HttpPut.class))).thenReturn(resp);
+
+        JSONObject payload = new JSONObject().put("description", "Updated");
+        assertDoesNotThrow(() -> categoryService.updateCategory("C1", payload));
+    }
+
+    @Test
+    void testDeleteCategorySuccess() throws Exception {
+        CloseableHttpResponse resp = prepareResponse(204, null);
+        when(httpClient.execute(any(HttpDelete.class))).thenReturn(resp);
+
+        assertDoesNotThrow(() -> categoryService.deleteCategory("C1"));
+    }
+
+    @Test
+    void testSearchCategoriesPagination() throws Exception {
+        JSONArray page1 = new JSONArray()
+                .put(new JSONObject().put("category_id", "C1"))
+                .put(new JSONObject().put("category_id", "C2"));
+        JSONArray page2 = new JSONArray().put(new JSONObject().put("category_id", "C3"));
+        CloseableHttpResponse resp1 = prepareResponse(200, page1.toString());
+        CloseableHttpResponse resp2 = prepareResponse(200, page2.toString());
+        when(httpClient.execute(any(HttpGet.class))).thenReturn(resp1, resp2);
+
+        JSONArray result = categoryService.searchCategories(null, new OperationOptionsBuilder().setPageSize(2).build());
+        assertEquals(3, result.length());
+    }
+}

--- a/src/test/java/com/identicum/connectors/services/PatronServiceTest.java
+++ b/src/test/java/com/identicum/connectors/services/PatronServiceTest.java
@@ -1,0 +1,103 @@
+package com.identicum.connectors.services;
+
+import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.client.methods.HttpPost;
+import org.apache.http.client.methods.HttpPut;
+import org.apache.http.client.methods.HttpDelete;
+import org.apache.http.client.methods.HttpRequestBase;
+import org.apache.http.entity.ContentType;
+import org.apache.http.entity.StringEntity;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.StatusLine;
+import org.apache.http.HttpEntity;
+import org.json.JSONArray;
+import org.json.JSONObject;
+import org.identityconnectors.framework.common.objects.OperationOptionsBuilder;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import java.io.IOException;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+public class PatronServiceTest {
+
+    @Mock
+    private CloseableHttpClient httpClient;
+
+    private PatronService patronService;
+
+    @BeforeEach
+    void setUp() {
+        patronService = new PatronService(httpClient, "http://localhost");
+    }
+
+    private CloseableHttpResponse prepareResponse(int status, String body) throws IOException {
+        CloseableHttpResponse response = mock(CloseableHttpResponse.class);
+        StatusLine statusLine = mock(StatusLine.class);
+        when(statusLine.getStatusCode()).thenReturn(status);
+        when(response.getStatusLine()).thenReturn(statusLine);
+        HttpEntity entity = body == null ? null : new StringEntity(body, ContentType.APPLICATION_JSON);
+        when(response.getEntity()).thenReturn(entity);
+        return response;
+    }
+
+    @Test
+    void testGetPatronSuccess() throws Exception {
+        CloseableHttpResponse resp = prepareResponse(200, "{\"patron_id\":1,\"userid\":\"jdoe\"}");
+        when(httpClient.execute(any(HttpGet.class))).thenReturn(resp);
+
+        JSONObject obj = patronService.getPatron("1");
+        assertEquals(1, obj.getInt("patron_id"));
+        assertEquals("jdoe", obj.getString("userid"));
+    }
+
+    @Test
+    void testCreatePatronSuccess() throws Exception {
+        CloseableHttpResponse resp = prepareResponse(200, "{\"patron_id\":2}");
+        when(httpClient.execute(any(HttpPost.class))).thenReturn(resp);
+
+        JSONObject payload = new JSONObject().put("userid", "newuser");
+        JSONObject created = patronService.createPatron(payload);
+        assertEquals(2, created.getInt("patron_id"));
+    }
+
+    @Test
+    void testUpdatePatronSuccess() throws Exception {
+        CloseableHttpResponse resp = prepareResponse(200, "{}");
+        when(httpClient.execute(any(HttpPut.class))).thenReturn(resp);
+
+        JSONObject payload = new JSONObject().put("email", "a@b.com");
+        assertDoesNotThrow(() -> patronService.updatePatron("1", payload));
+    }
+
+    @Test
+    void testDeletePatronSuccess() throws Exception {
+        CloseableHttpResponse resp = prepareResponse(204, null);
+        when(httpClient.execute(any(HttpDelete.class))).thenReturn(resp);
+
+        assertDoesNotThrow(() -> patronService.deletePatron("1"));
+    }
+
+    @Test
+    void testSearchPatronsPagination() throws Exception {
+        JSONArray page1 = new JSONArray()
+                .put(new JSONObject().put("patron_id", 1))
+                .put(new JSONObject().put("patron_id", 2));
+        JSONArray page2 = new JSONArray().put(new JSONObject().put("patron_id", 3));
+        CloseableHttpResponse resp1 = prepareResponse(200, page1.toString());
+        CloseableHttpResponse resp2 = prepareResponse(200, page2.toString());
+        when(httpClient.execute(any(HttpGet.class))).thenReturn(resp1, resp2);
+
+        JSONArray result = patronService.searchPatrons(null, new OperationOptionsBuilder().setPageSize(2).build());
+        assertEquals(3, result.length());
+    }
+}


### PR DESCRIPTION
## Summary
- add Mockito dependencies for unit testing
- add tests for `PatronService`
- add tests for `CategoryService`
- add integration tests for `KohaConnector.test()` using mocked services

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM: network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_686d869c8f108326b8d52119b157ca8e