### PR TITLE
Refactor KohaConnectorIntegrationTest with Mockito

### DIFF
--- a/src/test/java/com/identicum/connectors/KohaConnectorIntegrationTest.java
+++ b/src/test/java/com/identicum/connectors/KohaConnectorIntegrationTest.java
@@ -2,16 +2,14 @@ package com.identicum.connectors;
 
 import com.identicum.connectors.services.CategoryService;
 import com.identicum.connectors.services.PatronService;
-import org.identityconnectors.common.security.GuardedString;
 import org.identityconnectors.framework.common.exceptions.ConnectorIOException;
 import org.json.JSONArray;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
+import org.mockito.InjectMocks;
 import org.mockito.junit.jupiter.MockitoExtension;
-
-import java.lang.reflect.Field;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
@@ -25,25 +23,17 @@ public class KohaConnectorIntegrationTest {
     @Mock
     private CategoryService categoryService;
 
+    @Mock
+    private KohaConfiguration configuration;
+
+    @InjectMocks
     private KohaConnector connector;
 
     @BeforeEach
-    void setup() throws Exception {
-        connector = new KohaConnector();
-        KohaConfiguration cfg = new KohaConfiguration();
-        cfg.setServiceAddress("http://localhost");
-        cfg.setAuthenticationMethodStrategy("BASIC");
-        cfg.setUsername("u");
-        cfg.setPassword(new GuardedString("p".toCharArray()));
-        connector.init(cfg);
-        injectField(connector, "patronService", patronService);
-        injectField(connector, "categoryService", categoryService);
-    }
-
-    private static void injectField(Object target, String name, Object value) throws Exception {
-        Field f = target.getClass().getDeclaredField(name);
-        f.setAccessible(true);
-        f.set(target, value);
+    void setup() {
+        when(configuration.getServiceAddress()).thenReturn("http://localhost");
+        when(configuration.getAuthenticationMethodStrategy()).thenReturn("BASIC");
+        when(configuration.getUsername()).thenReturn("u");
     }
 
     @Test


### PR DESCRIPTION
## Summary
- refactor `KohaConnectorIntegrationTest` using `@InjectMocks`
- mock `KohaConfiguration`
- simplify setup and remove reflection helper

## Testing
- `mvn test` *(fails: `mvn` not found)*

------
https://chatgpt.com/codex/tasks/task_e_686da7f13cd88326bd728d9b9630a6a7