### PR TITLE
Update mockito-inline version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -76,7 +76,7 @@
 		<dependency>
 			<groupId>org.mockito</groupId>
 			<artifactId>mockito-inline</artifactId>
-			<version>5.2.0</version>
+			<version>5.11.0</version>
 			<scope>test</scope>
 		</dependency>
     </dependencies>


### PR DESCRIPTION
## Summary
- align `mockito-inline` with other Mockito dependencies by updating to version `5.11.0`

## Testing
- `mvn test` *(fails: Non-resolvable parent POM due to network issues)*

------
https://chatgpt.com/codex/tasks/task_e_687e6372a87c8326a05a1aaccebfb83d