### PR TITLE
Update mockito dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -63,20 +63,20 @@
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
-            <version>5.18.0</version>
+            <version>5.2.0</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-junit-jupiter</artifactId>
-            <version>5.18.0</version>
+            <version>5.2.0</version>
             <scope>test</scope>
         </dependency>
 		<!-- https://mvnrepository.com/artifact/org.mockito/mockito-inline -->
 		<dependency>
 			<groupId>org.mockito</groupId>
 			<artifactId>mockito-inline</artifactId>
-                        <version>5.18.0</version>
+                        <version>5.2.0</version>
 			<scope>test</scope>
 		</dependency>
     </dependencies>


### PR DESCRIPTION
## Summary
- set `mockito-core`, `mockito-junit-jupiter`, and `mockito-inline` to version 5.2.0

## Testing
- `mvn -q clean package` *(fails: Non-resolvable parent POM because `nexus.evolveum.com` is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_687eaed830bc8326a14657a212af2f6e